### PR TITLE
Proposed Fix For Canadian ACC hub support

### DIFF
--- a/app/app/composables/useApsProjects.ts
+++ b/app/app/composables/useApsProjects.ts
@@ -230,23 +230,7 @@ export function useApsProjects() {
   }
 
   function parseBim360Url(url: string): { projectId: string, folderId: string } | null {
-    try {
-      const parsed = new URL(url)
-      // Support: docs.b360.autodesk.com/projects/{id}/folders/{urn}/detail
-      // Support: acc.autodesk.com/docs/files/projects/{id}?folderUrn={urn}
-      const pathMatch = parsed.pathname.match(/\/projects\/([^/]+)\/folders\/([^/]+)/)
-      if (pathMatch) {
-        const projectId = pathMatch[1]
-        const folderId = decodeURIComponent(pathMatch[2])
-        return {
-          projectId: projectId.startsWith('b.') ? projectId : `b.${projectId}`,
-          folderId
-        }
-      }
-      return null
-    } catch {
-      return null
-    }
+    return parseAccUrl(url)
   }
 
   async function addExternalProject(url: string) {

--- a/app/app/utils/__tests__/parseAccUrl.test.ts
+++ b/app/app/utils/__tests__/parseAccUrl.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest'
+import { parseAccUrl } from '../index'
+
+describe('parseAccUrl', () => {
+  describe('BIM 360 pathname format', () => {
+    it('parses a standard BIM 360 URL with folder in pathname', () => {
+      const url =
+        'https://docs.b360.autodesk.com/projects/abc123/folders/urn%3Aadsk.wipsprod%3Afs.folder%3Aco.xyz/detail'
+      const result = parseAccUrl(url)
+      expect(result).toEqual({
+        projectId: 'b.abc123',
+        folderId: 'urn:adsk.wipsprod:fs.folder:co.xyz',
+      })
+    })
+
+    it('does not double-add the b. prefix when already present', () => {
+      const url =
+        'https://docs.b360.autodesk.com/projects/b.abc123/folders/urn%3Afolder%3Aid/detail'
+      const result = parseAccUrl(url)
+      expect(result?.projectId).toBe('b.abc123')
+    })
+  })
+
+  describe('ACC US format (folderUrn query param)', () => {
+    it('parses a standard ACC US URL', () => {
+      const url =
+        'https://acc.autodesk.com/docs/files/projects/abc123?folderUrn=urn%3Aadsk.wipsprod%3Afs.folder%3Aco.xyz'
+      const result = parseAccUrl(url)
+      expect(result).toEqual({
+        projectId: 'b.abc123',
+        folderId: 'urn:adsk.wipsprod:fs.folder:co.xyz',
+      })
+    })
+  })
+
+  describe('ACC Canada format (acc.can.autodesk.com)', () => {
+    it('parses the Canadian ACC URL from folderUrn query param', () => {
+      const url =
+        'https://acc.can.autodesk.com/docs/files/projects/ba22eefc-a47b-4960-979a-e97b06bcebdc?folderUrn=urn%3Aadsk.wips7bwc%3Afs.folder%3Aco.qDsq1BhNRyWTjFqU9mre9w&viewModel=detail&moduleId=folders'
+      const result = parseAccUrl(url)
+      expect(result).toEqual({
+        projectId: 'b.ba22eefc-a47b-4960-979a-e97b06bcebdc',
+        folderId: 'urn:adsk.wips7bwc:fs.folder:co.qDsq1BhNRyWTjFqU9mre9w',
+      })
+    })
+
+    it('does not double-add the b. prefix for Canadian URLs', () => {
+      const url =
+        'https://acc.can.autodesk.com/docs/files/projects/b.some-id?folderUrn=urn%3Afolder'
+      const result = parseAccUrl(url)
+      expect(result?.projectId).toBe('b.some-id')
+    })
+  })
+
+  describe('invalid inputs', () => {
+    it('returns null for a URL with no recognisable project/folder pattern', () => {
+      expect(parseAccUrl('https://acc.autodesk.com/dashboard')).toBeNull()
+    })
+
+    it('returns null for an ACC URL missing folderUrn', () => {
+      expect(
+        parseAccUrl('https://acc.autodesk.com/docs/files/projects/abc123')
+      ).toBeNull()
+    })
+
+    it('returns null for a completely invalid string', () => {
+      expect(parseAccUrl('not-a-url')).toBeNull()
+    })
+  })
+})

--- a/app/app/utils/index.ts
+++ b/app/app/utils/index.ts
@@ -2,6 +2,46 @@ export function randomInt(min: number, max: number): number {
   return Math.floor(Math.random() * (max - min + 1)) + min
 }
 
+/**
+ * Parse an Autodesk BIM 360 or ACC URL into a projectId and folderId.
+ *
+ * Supported formats:
+ *  - docs.b360.autodesk.com/projects/{id}/folders/{urn}/detail  (BIM 360)
+ *  - acc.autodesk.com/docs/files/projects/{id}?folderUrn={urn}  (ACC US)
+ *  - acc.can.autodesk.com/docs/files/projects/{id}?folderUrn={urn} (ACC Canada)
+ */
+export function parseAccUrl(url: string): { projectId: string; folderId: string } | null {
+  try {
+    const parsed = new URL(url)
+
+    // BIM 360 pathname format: /projects/{id}/folders/{urn}
+    const pathMatch = parsed.pathname.match(/\/projects\/([^/]+)\/folders\/([^/]+)/)
+    if (pathMatch) {
+      const projectId = pathMatch[1]!
+      const folderId = decodeURIComponent(pathMatch[2]!)
+      return {
+        projectId: projectId.startsWith('b.') ? projectId : `b.${projectId}`,
+        folderId,
+      }
+    }
+
+    // ACC format: /projects/{id}?folderUrn={urn}
+    const accPathMatch = parsed.pathname.match(/\/projects\/([^/?]+)/)
+    const folderUrn = parsed.searchParams.get('folderUrn')
+    if (accPathMatch && folderUrn) {
+      const projectId = accPathMatch[1]!
+      return {
+        projectId: projectId.startsWith('b.') ? projectId : `b.${projectId}`,
+        folderId: folderUrn,
+      }
+    }
+
+    return null
+  } catch {
+    return null
+  }
+}
+
 export function randomFrom<T>(array: T[]): T {
   return array[Math.floor(Math.random() * array.length)]!
 }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -20,7 +20,8 @@
     {
       "matches": [
         "https://docs.b360.autodesk.com/projects/*",
-        "https://acc.autodesk.com/docs/files/projects/*"
+        "https://acc.autodesk.com/docs/files/projects/*",
+        "https://acc.can.autodesk.com/docs/files/projects/*"
       ],
       "js": ["src/scripts/content.ts"]
     }

--- a/extension/src/scripts/background.ts
+++ b/extension/src/scripts/background.ts
@@ -69,7 +69,7 @@ function udpateTabUI(tab: chrome.tabs.Tab, tabId: number) {
     "https://docs.b360.autodesk.com/projects/.*/folders/.*/detail/viewer/items/.*"
   );
   const accRegexp = new RegExp(
-    "https://acc.autodesk.com/docs/files/projects/.*"
+    "https://acc(\\.[a-z]+)?\\.autodesk\\.com/docs/files/projects/.*"
   );
 
   if (!tab.url) return;


### PR DESCRIPTION
**_[manifest.json:21-24]_**  
Added acc.can.autodesk.com to content_scripts.matches so the extension's content script injects on the Canadian domain.

**_[background.ts:73-75]_**
Updated [accRegexp] from a hard-coded US domain to a pattern that matches regional subdomains:

  Before: 
  https://acc.autodesk.com/docs/files/projects/.*
  
  After: https://acc(\.[a-z]+)?\.autodesk\.com/docs/files/projects/.* 
  (matches acc.autodesk.com, acc.can.autodesk.com, acc.eu.autodesk.com, etc.)
 


**_[useApsProjects.ts:232-260]_**
Fixed _[parseBim360Url]_ to handle the ACC URL format where the folder is a query parameter. The function now:

1. First tries the BIM 360 pathname pattern 
([/projects/{id}/folders/{urn}]

2. Falls back to extracting project ID from [/projects/{id}] + reading [?folderUrn=] from query params, which is the format acc.can.autodesk.com uses

**_[parseAccUrl.test.ts]_**
Unit tests pass. 