### PR TITLE
fix: security hardening for server-side API routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@
 .claude
 .cursor
 /app/docs/*
+
+# Environment files
+.env
+.env.*
+!.env.example

--- a/app/nuxt.config.ts
+++ b/app/nuxt.config.ts
@@ -7,14 +7,18 @@ export default defineNuxtConfig({
   ],
 
   devtools: {
-    enabled: true
+    enabled: process.env.NODE_ENV !== 'production'
   },
 
   css: ['~/assets/css/main.css'],
 
   routeRules: {
     '/api/**': {
-      cors: true
+      headers: {
+        'X-Content-Type-Options': 'nosniff',
+        'X-Frame-Options': 'DENY',
+        'Referrer-Policy': 'strict-origin-when-cross-origin'
+      }
     }
   },
 

--- a/app/server/api/aps/derivative.get.ts
+++ b/app/server/api/aps/derivative.get.ts
@@ -1,27 +1,28 @@
-export default eventHandler(async (event) => {
-  const { urn, derivativeUrn, mimeType, region } = getQuery(event)
+import { validateUrn, validateDerivativeUrn, validateRegion, sanitizeHeaderFilename } from '../../utils/validation'
 
-  if (!urn || !derivativeUrn) {
+export default eventHandler(async (event) => {
+  const query = getQuery(event)
+
+  if (!query.urn || !query.derivativeUrn) {
     throw createError({ statusCode: 400, statusMessage: 'urn and derivativeUrn are required' })
   }
 
+  const urn = validateUrn(query.urn as string)
+  const derivativeUrnValue = validateDerivativeUrn(query.derivativeUrn as string)
+  const region = validateRegion(query.region as string | undefined)
+
   const token = await getApsAccessToken(event)
 
-  const signedInfo = await getSignedDerivativeUrl(
-    urn as string,
-    derivativeUrn as string,
-    token,
-    region as string | undefined
-  )
+  const signedInfo = await getSignedDerivativeUrl(urn, derivativeUrnValue, token, region)
+  const file = await downloadDerivative(signedInfo, derivativeUrnValue)
 
-  const file = await downloadDerivative(signedInfo, derivativeUrn as string)
-
-  const contentType = (mimeType as string) || inferMimeType(derivativeUrn as string)
+  const contentType = (query.mimeType as string) || inferMimeType(derivativeUrnValue)
   const isInline = contentType.startsWith('image/') || contentType === 'application/pdf' || contentType === 'application/json'
+  const safeName = sanitizeHeaderFilename(file.name)
 
   setResponseHeaders(event, {
     'Content-Type': contentType,
-    'Content-Disposition': `${isInline ? 'inline' : 'attachment'}; filename="${file.name}"`
+    'Content-Disposition': `${isInline ? 'inline' : 'attachment'}; filename="${safeName}"`
   })
 
   return file.data

--- a/app/server/api/aps/export-derivatives.post.ts
+++ b/app/server/api/aps/export-derivatives.post.ts
@@ -2,6 +2,7 @@ import archiver from 'archiver'
 import { PassThrough } from 'node:stream'
 import { parseExportBody, sanitizeFolderName, inferMimeType } from '../../utils/aps-download'
 import { mergePdfBuffers } from '../../utils/pdf-merge'
+import { validateRegion, sanitizeHeaderFilename } from '../../utils/validation'
 
 interface DerivativeFile {
   name: string
@@ -19,7 +20,7 @@ export default eventHandler(async (event) => {
 
   const rawToken = await getApsAccessToken(event)
 
-  const region = body.region as string | undefined
+  const region = validateRegion(body.region as string | undefined)
 
   // Download all derivatives from all file groups in parallel
   const allDownloads = await Promise.all(
@@ -123,7 +124,7 @@ export default eventHandler(async (event) => {
       const mimeType = inferMimeType(file.name)
       setResponseHeaders(event, {
         'Content-Type': mimeType,
-        'Content-Disposition': `attachment; filename="${file.name}"`
+        'Content-Disposition': `attachment; filename="${sanitizeHeaderFilename(file.name)}"`
       })
       return file.data
     }

--- a/app/server/api/aps/folder-contents.get.ts
+++ b/app/server/api/aps/folder-contents.get.ts
@@ -1,11 +1,15 @@
 import { normalizeFolderContents } from '../../utils/aps-normalize'
+import { validateApsId } from '../../utils/validation'
 
 export default eventHandler(async (event) => {
-  const { projectId, folderId } = getQuery(event)
+  const query = getQuery(event)
 
-  if (!projectId || !folderId) {
+  if (!query.projectId || !query.folderId) {
     throw createError({ statusCode: 400, statusMessage: 'projectId and folderId are required' })
   }
+
+  const projectId = validateApsId(query.projectId as string)
+  const folderId = validateApsId(query.folderId as string)
 
   const token = await getApsAccessToken(event)
 

--- a/app/server/api/aps/item-urn.get.ts
+++ b/app/server/api/aps/item-urn.get.ts
@@ -1,4 +1,5 @@
 import { normalizeItemUrn } from '../../utils/aps-item'
+import { validateApsId } from '../../utils/validation'
 
 interface ApsTipResponse {
   data: {
@@ -13,11 +14,14 @@ interface ApsTipResponse {
 }
 
 export default eventHandler(async (event) => {
-  const { projectId, itemId } = getQuery(event)
+  const query = getQuery(event)
 
-  if (!projectId || !itemId) {
+  if (!query.projectId || !query.itemId) {
     throw createError({ statusCode: 400, statusMessage: 'projectId and itemId are required' })
   }
+
+  const projectId = validateApsId(query.projectId as string)
+  const itemId = validateApsId(query.itemId as string)
 
   const token = await getApsAccessToken(event)
 

--- a/app/server/api/aps/manifest.get.ts
+++ b/app/server/api/aps/manifest.get.ts
@@ -1,19 +1,23 @@
 import type { ApsManifest } from '~/types/derivatives'
 import { filterDerivatives, extractViewSets, checkRevitVersion } from '../../utils/derivatives'
+import { validateUrn, validateRegion } from '../../utils/validation'
 
 export default eventHandler(async (event) => {
-  const { urn, region } = getQuery(event)
+  const query = getQuery(event)
 
-  if (!urn) {
+  if (!query.urn) {
     throw createError({ statusCode: 400, statusMessage: 'urn is required' })
   }
+
+  const urn = validateUrn(query.urn as string)
+  const region = validateRegion(query.region as string | undefined)
 
   const token = await getApsAccessToken(event)
 
   const manifest = await apsFetch<ApsManifest>(
     token,
-    modelDerivativePath(`/modelderivative/v2/designdata/${urn}/manifest`, region as string | undefined),
-    region as string | undefined
+    modelDerivativePath(`/modelderivative/v2/designdata/${urn}/manifest`, region),
+    region
   )
 
   const firstDerivative = manifest.derivatives[0]

--- a/app/server/api/aps/projects.get.ts
+++ b/app/server/api/aps/projects.get.ts
@@ -1,11 +1,14 @@
 import type { ApsProject } from '~/types/aps'
+import { validateApsId } from '../../utils/validation'
 
 export default eventHandler(async (event) => {
-  const { hubId } = getQuery(event)
+  const query = getQuery(event)
 
-  if (!hubId) {
+  if (!query.hubId) {
     throw createError({ statusCode: 400, statusMessage: 'hubId is required' })
   }
+
+  const hubId = validateApsId(query.hubId as string)
 
   const token = await getApsAccessToken(event)
 
@@ -17,7 +20,7 @@ export default eventHandler(async (event) => {
   const projects: ApsProject[] = response.data.map(project => ({
     id: project.id,
     name: project.attributes.name,
-    hubId: hubId as string
+    hubId
   }))
 
   return projects

--- a/app/server/api/aps/revit-files.get.ts
+++ b/app/server/api/aps/revit-files.get.ts
@@ -1,15 +1,20 @@
 import { searchRevitFiles } from '../../utils/aps-traversal'
+import { validateApsId } from '../../utils/validation'
 
 export default eventHandler(async (event) => {
-  const { hubId, projectId, folderId } = getQuery(event)
+  const query = getQuery(event)
 
-  if (!projectId) {
+  if (!query.projectId) {
     throw createError({ statusCode: 400, statusMessage: 'projectId is required' })
   }
 
-  if (!hubId && !folderId) {
+  if (!query.hubId && !query.folderId) {
     throw createError({ statusCode: 400, statusMessage: 'hubId or folderId is required' })
   }
+
+  const projectId = validateApsId(query.projectId as string)
+  const hubId = query.hubId ? validateApsId(query.hubId as string) : undefined
+  const folderId = query.folderId ? validateApsId(query.folderId as string) : undefined
 
   const token = await getApsAccessToken(event)
 
@@ -28,7 +33,7 @@ export default eventHandler(async (event) => {
       // External project: search the provided folder directly
       // The search endpoint recursively searches all subfolders server-side,
       // so we don't need to list subfolders and search each one individually
-      topFolders = [{ id: folderId as string, path: 'Project Files' }]
+      topFolders = [{ id: folderId!, path: 'Project Files' }]
     } else {
       // Normal hub project: fetch top folders via hubs API
       const topFoldersResponse = await apsFetch<{ data: Array<{ id: string, type: string, attributes: { displayName?: string, name?: string } }> }>(
@@ -61,7 +66,7 @@ export default eventHandler(async (event) => {
 
     await searchRevitFiles(
       fetchFn,
-      projectId as string,
+      projectId,
       topFolders,
       (folder, searched) => {
         send({ type: 'progress', folder, scanned: searched })

--- a/app/server/api/aps/top-folders.get.ts
+++ b/app/server/api/aps/top-folders.get.ts
@@ -1,11 +1,15 @@
 import type { ApsFolderContent } from '~/types/aps'
+import { validateApsId } from '../../utils/validation'
 
 export default eventHandler(async (event) => {
-  const { hubId, projectId } = getQuery(event)
+  const query = getQuery(event)
 
-  if (!hubId || !projectId) {
+  if (!query.hubId || !query.projectId) {
     throw createError({ statusCode: 400, statusMessage: 'hubId and projectId are required' })
   }
+
+  const hubId = validateApsId(query.hubId as string)
+  const projectId = validateApsId(query.projectId as string)
 
   const token = await getApsAccessToken(event)
 

--- a/app/server/api/auth/aps/exchange.post.ts
+++ b/app/server/api/auth/aps/exchange.post.ts
@@ -40,10 +40,9 @@ export default eventHandler(async (event) => {
   })
 
   if (!tokenResponse.ok) {
-    const errorData = await tokenResponse.json().catch(() => ({}))
     throw createError({
       statusCode: tokenResponse.status,
-      message: `Token exchange failed: ${errorData.error_description || errorData.error || 'Unknown error'}`
+      message: 'Token exchange failed'
     })
   }
 

--- a/app/server/api/auth/check.ts
+++ b/app/server/api/auth/check.ts
@@ -1,8 +1,8 @@
 export default eventHandler(async (event) => {
-  const accessToken = getCookie(event, 'aps_access_token')
-  const refreshToken = getCookie(event, 'aps_refresh_token')
-
-  return {
-    authenticated: !!(accessToken || refreshToken)
+  try {
+    await getApsAccessToken(event)
+    return { authenticated: true }
+  } catch {
+    return { authenticated: false }
   }
 })

--- a/app/server/tests/aps/aps-download.test.ts
+++ b/app/server/tests/aps/aps-download.test.ts
@@ -70,5 +70,17 @@ describe('aps-download utilities', () => {
     it('returns fallback for empty URN', () => {
       expect(deriveFileName('')).toBe('unknown')
     })
+
+    it('strips double quotes from filename to prevent header breakout', () => {
+      expect(deriveFileName('output/file"name.pdf')).toBe('filename.pdf')
+    })
+
+    it('strips newlines from filename to prevent header injection', () => {
+      expect(deriveFileName('output/file\r\nX-Injected: evil.pdf')).toBe('fileX-Injected: evil.pdf')
+    })
+
+    it('strips backslashes from filename', () => {
+      expect(deriveFileName('output/path\\file.pdf')).toBe('pathfile.pdf')
+    })
   })
 })

--- a/app/server/tests/aps/aps-fetch.test.ts
+++ b/app/server/tests/aps/aps-fetch.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest'
+import { buildApsUrl } from '../../utils/aps'
+
+describe('buildApsUrl', () => {
+  it('prepends APS base URL to relative paths', () => {
+    expect(buildApsUrl('/project/v1/hubs')).toBe('https://developer.api.autodesk.com/project/v1/hubs')
+  })
+
+  it('allows full URLs under the APS domain', () => {
+    const url = 'https://developer.api.autodesk.com/data/v1/projects/123/folders/456/contents'
+    expect(buildApsUrl(url)).toBe(url)
+  })
+
+  it('rejects arbitrary URLs that are not under the APS domain', () => {
+    expect(() => buildApsUrl('https://evil.com/steal-token')).toThrow()
+    expect(() => buildApsUrl('http://169.254.169.254/latest/meta-data')).toThrow()
+  })
+
+  it('rejects URLs that try to impersonate the APS domain', () => {
+    expect(() => buildApsUrl('https://developer.api.autodesk.com.evil.com/path')).toThrow()
+    expect(() => buildApsUrl('https://evil-developer.api.autodesk.com/path')).toThrow()
+  })
+})

--- a/app/server/tests/aps/error-sanitization.test.ts
+++ b/app/server/tests/aps/error-sanitization.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest'
+import { sanitizeApsError } from '../../utils/aps'
+
+describe('sanitizeApsError', () => {
+  it('returns generic message without leaking upstream details', () => {
+    const result = sanitizeApsError(502, { detail: 'internal APS structure leaked' })
+    expect(result).not.toContain('internal APS structure')
+    expect(result).toContain('APS API error')
+  })
+
+  it('includes the status code for debugging context', () => {
+    const result = sanitizeApsError(404, 'Not found')
+    expect(result).toContain('404')
+  })
+
+  it('does not include raw error data or stack traces', () => {
+    const result = sanitizeApsError(500, {
+      stack: 'Error at line 42...',
+      data: { secret: 'token123' }
+    })
+    expect(result).not.toContain('token123')
+    expect(result).not.toContain('line 42')
+    expect(result).not.toContain('stack')
+  })
+})

--- a/app/server/tests/aps/export-derivatives.test.ts
+++ b/app/server/tests/aps/export-derivatives.test.ts
@@ -101,6 +101,40 @@ describe('export-derivatives endpoint', () => {
 
   })
 
+  describe('export limits', () => {
+    it('rejects requests with more than 50 file groups', () => {
+      const files = Array.from({ length: 51 }, (_, i) => ({
+        urn: `urn${i}`,
+        derivatives: ['d1']
+      }))
+      const result = parseExportBody({ files })
+      expect('error' in result).toBe(true)
+      if ('error' in result) {
+        expect(result.error).toContain('Too many')
+      }
+    })
+
+    it('rejects file groups with more than 200 derivatives each', () => {
+      const derivatives = Array.from({ length: 201 }, (_, i) => `d${i}`)
+      const result = parseExportBody({
+        files: [{ urn: 'urn1', derivatives }]
+      })
+      expect('error' in result).toBe(true)
+      if ('error' in result) {
+        expect(result.error).toContain('Too many derivatives')
+      }
+    })
+
+    it('accepts requests at the limit', () => {
+      const files = Array.from({ length: 50 }, (_, i) => ({
+        urn: `urn${i}`,
+        derivatives: ['d1']
+      }))
+      const result = parseExportBody({ files })
+      expect('fileGroups' in result).toBe(true)
+    })
+  })
+
   describe('sanitizeFolderName', () => {
     it('replaces special characters with underscores', () => {
       expect(sanitizeFolderName('file<>:"/\\|?*name')).toBe('file_________name')

--- a/app/server/tests/aps/validation.test.ts
+++ b/app/server/tests/aps/validation.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest'
+import {
+  validateApsId,
+  validateUrn,
+  validateDerivativeUrn,
+  validateRegion,
+  sanitizeHeaderFilename
+} from '../../utils/validation'
+
+describe('validateApsId', () => {
+  it('accepts valid APS IDs (alphanumeric, dots, dashes, underscores, colons)', () => {
+    expect(validateApsId('b.1234-abcd')).toBe('b.1234-abcd')
+    expect(validateApsId('urn:adsk.wipprod:fs.folder:co.abc123')).toBe('urn:adsk.wipprod:fs.folder:co.abc123')
+    expect(validateApsId('a.hub_123')).toBe('a.hub_123')
+  })
+
+  it('rejects IDs with path traversal', () => {
+    expect(() => validateApsId('../etc/passwd')).toThrow()
+    expect(() => validateApsId('valid/../../bad')).toThrow()
+  })
+
+  it('rejects IDs with newlines or control characters', () => {
+    expect(() => validateApsId('id\ninjection')).toThrow()
+    expect(() => validateApsId('id\r\nheader: value')).toThrow()
+  })
+
+  it('rejects empty strings', () => {
+    expect(() => validateApsId('')).toThrow()
+  })
+
+  it('rejects IDs that are too long', () => {
+    expect(() => validateApsId('a'.repeat(1001))).toThrow()
+  })
+})
+
+describe('validateUrn', () => {
+  it('accepts valid base64-encoded URNs', () => {
+    const urn = 'dXJuOmFkc2sud2lwcHJvZDpkbS5saW5lYWdlOmFiYzEyMw'
+    expect(validateUrn(urn)).toBe(urn)
+  })
+
+  it('accepts URNs with base64url characters (-, _, =)', () => {
+    const urn = 'dXJuOmFkc2sud2lwcHJvZDpk-bS5saW5lYWdl_abc=='
+    expect(validateUrn(urn)).toBe(urn)
+  })
+
+  it('rejects URNs with path traversal', () => {
+    expect(() => validateUrn('../../../etc/passwd')).toThrow()
+  })
+
+  it('rejects URNs with newlines', () => {
+    expect(() => validateUrn('valid\ninjection')).toThrow()
+  })
+
+  it('rejects empty URNs', () => {
+    expect(() => validateUrn('')).toThrow()
+  })
+})
+
+describe('validateDerivativeUrn', () => {
+  it('accepts valid derivative URNs with slashes', () => {
+    const urn = 'urn:adsk.viewing:fs.file:abc123/output/Resource/sheet/1234-abcd/A101 - Floor Plan.pdf'
+    expect(validateDerivativeUrn(urn)).toBe(urn)
+  })
+
+  it('accepts derivative URNs with spaces and dots', () => {
+    const urn = 'output/some file.pdf'
+    expect(validateDerivativeUrn(urn)).toBe(urn)
+  })
+
+  it('rejects derivative URNs with newlines', () => {
+    expect(() => validateDerivativeUrn('file\r\nX-Injected: evil')).toThrow()
+  })
+
+  it('rejects empty string', () => {
+    expect(() => validateDerivativeUrn('')).toThrow()
+  })
+})
+
+describe('validateRegion', () => {
+  it('accepts valid region values', () => {
+    expect(validateRegion('US')).toBe('US')
+    expect(validateRegion('EMEA')).toBe('EMEA')
+    expect(validateRegion(undefined)).toBeUndefined()
+  })
+
+  it('rejects invalid region values', () => {
+    expect(() => validateRegion('EVIL')).toThrow()
+    expect(() => validateRegion('../etc')).toThrow()
+  })
+})
+
+describe('sanitizeHeaderFilename', () => {
+  it('passes through safe filenames', () => {
+    expect(sanitizeHeaderFilename('floor-plan.pdf')).toBe('floor-plan.pdf')
+    expect(sanitizeHeaderFilename('Sheet A101.pdf')).toBe('Sheet A101.pdf')
+  })
+
+  it('strips double quotes to prevent header breakout', () => {
+    expect(sanitizeHeaderFilename('file"name.pdf')).toBe('filename.pdf')
+  })
+
+  it('strips newlines to prevent header injection', () => {
+    expect(sanitizeHeaderFilename('file\r\nX-Injected: evil')).toBe('fileX-Injected: evil')
+  })
+
+  it('strips backslashes', () => {
+    expect(sanitizeHeaderFilename('path\\file.pdf')).toBe('pathfile.pdf')
+  })
+
+  it('returns "download" for empty or whitespace-only input', () => {
+    expect(sanitizeHeaderFilename('')).toBe('download')
+    expect(sanitizeHeaderFilename('   ')).toBe('download')
+  })
+})

--- a/app/server/utils/aps-download.ts
+++ b/app/server/utils/aps-download.ts
@@ -33,7 +33,9 @@ export function buildCloudFrontUrl(url: string, policy: string, keyPairId: strin
 
 export function deriveFileName(derivativeUrn: string): string {
   const parts = derivativeUrn.split('/')
-  return parts[parts.length - 1] || 'unknown'
+  const raw = parts[parts.length - 1] || 'unknown'
+  const sanitized = raw.replace(/[\r\n"\\]/g, '').trim()
+  return sanitized || 'unknown'
 }
 
 export function inferMimeType(urn: string): string {
@@ -123,6 +125,9 @@ export function sanitizeFolderName(name: string): string {
   return name.replace(/[<>:"/\\|?*]/g, '_').trim() || 'unknown'
 }
 
+const MAX_FILE_GROUPS = 50
+const MAX_DERIVATIVES_PER_GROUP = 200
+
 export function parseExportBody(body: ExportBody): { fileGroups: FileGroup[], options: ParsedExportOptions } | { error: string } {
   const rawMerge = body.options?.mergeScope
   const options: ParsedExportOptions = {
@@ -133,10 +138,14 @@ export function parseExportBody(body: ExportBody): { fileGroups: FileGroup[], op
 
   if (body.files && Array.isArray(body.files)) {
     if (body.files.length === 0) return { error: 'files must be a non-empty array' }
+    if (body.files.length > MAX_FILE_GROUPS) return { error: `Too many file groups (max ${MAX_FILE_GROUPS})` }
     for (const group of body.files) {
       if (!group.urn) return { error: 'Each file must have a urn' }
       if (!group.derivatives || !Array.isArray(group.derivatives) || group.derivatives.length === 0) {
         return { error: 'Each file must have a non-empty derivatives array' }
+      }
+      if (group.derivatives.length > MAX_DERIVATIVES_PER_GROUP) {
+        return { error: `Too many derivatives per file (max ${MAX_DERIVATIVES_PER_GROUP})` }
       }
     }
     return { fileGroups: body.files, options }
@@ -145,6 +154,9 @@ export function parseExportBody(body: ExportBody): { fileGroups: FileGroup[], op
   if (!body.urn) return { error: 'urn is required' }
   if (!body.derivatives || !Array.isArray(body.derivatives) || body.derivatives.length === 0) {
     return { error: 'derivatives must be a non-empty array' }
+  }
+  if (body.derivatives.length > MAX_DERIVATIVES_PER_GROUP) {
+    return { error: `Too many derivatives per file (max ${MAX_DERIVATIVES_PER_GROUP})` }
   }
   return { fileGroups: [{ urn: body.urn, derivatives: body.derivatives }], options }
 }

--- a/app/server/utils/aps.ts
+++ b/app/server/utils/aps.ts
@@ -82,8 +82,23 @@ export function regionHeader(region?: string): Record<string, string> {
   return {}
 }
 
+export function buildApsUrl(path: string): string {
+  if (path.startsWith('http')) {
+    const parsed = new URL(path)
+    if (parsed.hostname !== 'developer.api.autodesk.com') {
+      throw new Error(`Blocked request to non-APS domain: ${parsed.hostname}`)
+    }
+    return path
+  }
+  return `${APS_BASE_URL}${path}`
+}
+
+export function sanitizeApsError(statusCode: number, _detail: unknown): string {
+  return `APS API error (${statusCode})`
+}
+
 export async function apsFetch<T>(token: string, path: string, region?: string): Promise<T> {
-  const url = path.startsWith('http') ? path : `${APS_BASE_URL}${path}`
+  const url = buildApsUrl(path)
   try {
     return await $fetch(url, {
       headers: {
@@ -93,10 +108,14 @@ export async function apsFetch<T>(token: string, path: string, region?: string):
     }) as T
   } catch (err: unknown) {
     const fetchErr = err as { status?: number, data?: unknown, message?: string }
-    const detail = fetchErr.data ? JSON.stringify(fetchErr.data) : fetchErr.message
+    const status = fetchErr.status || 502
+    if (import.meta.dev) {
+      const detail = fetchErr.data ? JSON.stringify(fetchErr.data) : fetchErr.message
+      console.error(`[APS] ${status}: ${detail}`)
+    }
     throw createError({
-      statusCode: fetchErr.status || 502,
-      statusMessage: `APS API error: ${detail}`
+      statusCode: status,
+      statusMessage: sanitizeApsError(status, fetchErr.data)
     })
   }
 }

--- a/app/server/utils/validation.ts
+++ b/app/server/utils/validation.ts
@@ -1,0 +1,48 @@
+import { z } from 'zod'
+
+const APS_ID_PATTERN = /^[a-zA-Z0-9._:~\-]+$/
+const URN_PATTERN = /^[a-zA-Z0-9_\-+=]+$/
+const MAX_ID_LENGTH = 1000
+
+const apsIdSchema = z
+  .string()
+  .min(1, 'ID must not be empty')
+  .max(MAX_ID_LENGTH, 'ID too long')
+  .regex(APS_ID_PATTERN, 'Invalid APS ID format')
+
+const urnSchema = z
+  .string()
+  .min(1, 'URN must not be empty')
+  .max(MAX_ID_LENGTH, 'URN too long')
+  .regex(URN_PATTERN, 'Invalid URN format')
+
+const derivativeUrnSchema = z
+  .string()
+  .min(1, 'Derivative URN must not be empty')
+  .max(2000, 'Derivative URN too long')
+  .refine(val => !/[\r\n]/.test(val), 'Derivative URN must not contain newlines')
+
+const VALID_REGIONS = ['US', 'EMEA'] as const
+const regionSchema = z.enum(VALID_REGIONS)
+
+export function validateApsId(value: string): string {
+  return apsIdSchema.parse(value)
+}
+
+export function validateUrn(value: string): string {
+  return urnSchema.parse(value)
+}
+
+export function validateDerivativeUrn(value: string): string {
+  return derivativeUrnSchema.parse(value)
+}
+
+export function validateRegion(value: string | undefined): string | undefined {
+  if (value === undefined || value === '') return undefined
+  return regionSchema.parse(value)
+}
+
+export function sanitizeHeaderFilename(name: string): string {
+  const sanitized = name.replace(/[\r\n"\\]/g, '').trim()
+  return sanitized || 'download'
+}


### PR DESCRIPTION
## Summary

- **Input validation**: Added Zod schemas on all `/api/aps/*` query params (`urn`, `hubId`, `projectId`, `folderId`, `itemId`, `derivativeUrn`, `region`) to reject path traversal, injection, and malformed values
- **SSRF fix**: `apsFetch` now rejects requests to non-APS domains via `buildApsUrl()`
- **Header injection fix**: `deriveFileName()` and `Content-Disposition` headers sanitize `"`, `\r\n`, `\` from filenames
- **Error leaking fix**: `apsFetch` returns generic `APS API error (status)` instead of forwarding upstream error details to clients
- **Auth check fix**: `/api/auth/check` now validates the token (triggers refresh) instead of just checking cookie existence
- **CORS removed**: Removed wildcard `cors: true` from all API routes
- **Security headers added**: `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy: strict-origin-when-cross-origin`
- **Export limits**: Max 50 file groups, 200 derivatives per group to prevent OOM
- **Root `.gitignore`**: Added `.env` / `.env.*` to prevent accidental credential commits
- **DevTools**: Disabled in production

## Test plan

- [x] 164 tests passing (34 new), 0 failures
- [ ] Verify bad query params return 400 (e.g. `?hubId=../etc/passwd`)
- [ ] Verify CORS headers no longer include `Access-Control-Allow-Origin: *`
- [ ] Verify security headers present on API responses
- [ ] Verify export with >50 file groups returns 400
- [ ] Verify error responses don't leak upstream APS details