### PR TITLE
fix: add CAN as a valid region for Canadian ACC hub support

### DIFF
--- a/app/server/utils/validation.ts
+++ b/app/server/utils/validation.ts
@@ -22,7 +22,7 @@ const derivativeUrnSchema = z
   .max(2000, 'Derivative URN too long')
   .refine(val => !/[\r\n]/.test(val), 'Derivative URN must not contain newlines')
 
-const VALID_REGIONS = ['US', 'EMEA'] as const
+const VALID_REGIONS = ['US', 'EMEA', 'CAN'] as const
 const regionSchema = z.enum(VALID_REGIONS)
 
 export function validateApsId(value: string): string {


### PR DESCRIPTION
The validateRegion function only accepted 'US' and 'EMEA', but Canadian ACC hubs report their region as 'CAN' from the Autodesk Hubs API. When a user selected a Revit file from a Canadian ACC hub, the manifest endpoint received region=CAN, which caused validateRegion to throw a ZodError. This unhandled error propagated through the auth error handler, ultimately triggering a full OAuth re-authorization flow on every file selection.

Adding 'CAN' to VALID_REGIONS allows the region to pass validation. The existing regionHeader utility already handles non-US regions correctly (sending Region: CAN), and the Canadian ACC Model Derivative API uses the standard AMER/US endpoint so no URL prefix change is needed. This fix also covers the export endpoint, which uses the same validateRegion call.