### PR TITLE
PDF-first stabilization: simple print-set downloads for normal users, advanced data on demand

### DIFF
--- a/app/app/components/ApsProjectTree.vue
+++ b/app/app/components/ApsProjectTree.vue
@@ -2,9 +2,11 @@
 import type { TreeItemToggleEvent } from 'reka-ui'
 import type { TreeItem } from '@nuxt/ui'
 import type { ApsTreeItem } from '~/types/aps'
+import type { FavoriteProject } from '~/utils/favorites'
 
 const {
   items,
+  expandedKeys,
   loading,
   warnings,
   searchingProject,
@@ -12,15 +14,22 @@ const {
   searchResults,
   loadHubs,
   handleToggle,
+  expandNode,
   searchRevitFiles,
   addManualHub,
-  addExternalProject
+  addExternalProject,
+  rehydrateStored,
+  removeExternalProject,
+  favoriteProjects,
+  toggleFavorite,
+  isFavorite,
+  openFavorite
 } = useApsProjects()
 
 const { isFileSelected, toggleFile, removeFile } = useDerivatives()
 const runtimeConfig = useRuntimeConfig()
 
-const selectedProject = ref<ApsTreeItem | null>(null)
+const selectedProject = shallowRef<ApsTreeItem | null>(null)
 const error = ref<string | null>(null)
 const manualHubId = ref('')
 const showManualInput = ref(false)
@@ -47,27 +56,14 @@ watch(searchingProject, (newVal, oldVal) => {
   }
 })
 
-function filterTree(nodes: ApsTreeItem[], query: string): ApsTreeItem[] {
-  if (!query) return nodes
-  const q = query.toLowerCase()
-  return nodes.reduce<ApsTreeItem[]>((acc, node) => {
-    const labelMatch = node.label?.toLowerCase().includes(q)
-    const filteredChildren = node.children ? filterTree(node.children, query) : []
-    if (labelMatch || filteredChildren.length > 0) {
-      acc.push({ ...node, children: filteredChildren.length > 0 ? filteredChildren : node.children })
-    }
-    return acc
-  }, [])
-}
-
-const filteredItems = computed(() => filterTree(items.value, treeFilter.value))
+const filteredItems = computed<ApsTreeItem[]>(() => filterProjectTree(items.value as ApsTreeItem[], treeFilter.value))
 
 function selectAllResults() {
   const project = selectedProject.value
   if (!project?._projectId) return
   for (const file of searchResults.value) {
     if (!isFileSelected(file.id)) {
-      toggleFile(file.id, project._projectId, file.name, project._region)
+      toggleFile(file.id, project._projectId, file.name, project._region, project._projectName ?? project.label)
     }
   }
 }
@@ -105,11 +101,15 @@ onMounted(async () => {
     await loadHubs()
   } catch (e: unknown) {
     error.value = e instanceof Error ? e.message : 'Failed to load hubs'
+  } finally {
+    // Restore saved manual hubs / external projects after loadHubs
+    // replaced the tree (and even if it failed)
+    rehydrateStored()
   }
 })
 
-function onToggle(e: TreeItemToggleEvent<TreeItem>, item: TreeItem) {
-  handleToggle(item as ApsTreeItem, e.detail.isExpanded)
+function onToggle(_e: TreeItemToggleEvent<TreeItem>, item: TreeItem) {
+  handleToggle(item as ApsTreeItem)
 }
 
 function isRvtItem(item: ApsTreeItem): boolean {
@@ -130,7 +130,7 @@ function onSelect(_e: unknown, item: TreeItem) {
     const itemId = getItemId(apsItem)
     const projectId = apsItem._projectId
     if (!projectId) return
-    toggleFile(itemId, projectId, apsItem.label || '', apsItem._region)
+    toggleFile(itemId, projectId, apsItem.label || '', apsItem._region, apsItem._projectName)
   }
 }
 
@@ -142,10 +142,36 @@ function onSearchRevitFiles(project: ApsTreeItem) {
   searchRevitFiles(project._hubId, project._projectId, project._folderId)
 }
 
+const treeContainer = ref<HTMLElement | null>(null)
+
+async function onFavoriteClick(fav: FavoriteProject) {
+  // An active filter could hide the target row
+  treeFilter.value = ''
+  const apsId = await openFavorite(fav)
+  if (!apsId) return
+
+  // Wait for the expanded rows to render, then scroll + flash the row
+  for (let attempt = 0; attempt < 10; attempt++) {
+    await nextTick()
+    const marker = treeContainer.value?.querySelector(`[data-aps-id="${CSS.escape(apsId)}"]`)
+    const row = marker?.closest('[role="treeitem"]') as HTMLElement | null
+    if (row) {
+      row.scrollIntoView({ block: 'center', behavior: 'smooth' })
+      row.classList.add('ring-2', 'ring-primary', 'rounded-md', 'transition')
+      setTimeout(() => row.classList.remove('ring-2', 'ring-primary', 'rounded-md', 'transition'), 1600)
+      return
+    }
+    await new Promise(resolve => setTimeout(resolve, 50))
+  }
+}
+
 function onSearchResultClick(fileId: string, fileName: string) {
   const project = selectedProject.value
   if (!project?._projectId) return
-  toggleFile(fileId, project._projectId, fileName, project._region)
+  const adding = !isFileSelected(fileId)
+  toggleFile(fileId, project._projectId, fileName, project._region, project._projectName ?? project.label)
+  // Expand the owning project so the tree doesn't look empty
+  if (adding) expandNode(project)
 }
 </script>
 
@@ -282,6 +308,26 @@ function onSearchResultClick(fileId: string, fileName: string) {
         Loading hubs...
       </div>
 
+      <ClientOnly>
+        <div v-if="!loading && favoriteProjects.length > 0" class="flex flex-col gap-1">
+          <p class="text-xs font-medium text-muted">
+            Favorites
+          </p>
+          <div class="flex flex-wrap gap-1">
+            <UButton
+              v-for="fav in favoriteProjects"
+              :key="`${fav.projectId}-${fav.folderId || ''}`"
+              size="xs"
+              variant="subtle"
+              color="neutral"
+              icon="i-lucide-star"
+              :label="fav.label"
+              @click="onFavoriteClick(fav)"
+            />
+          </div>
+        </div>
+      </ClientOnly>
+
       <UInput
         v-if="!loading && items.length > 0"
         v-model="treeFilter"
@@ -303,68 +349,90 @@ function onSearchResultClick(fileId: string, fileName: string) {
         </template>
       </UInput>
 
-      <UTree
-        v-if="!loading"
-        :items="filteredItems"
-        :get-key="(item: TreeItem) => (item as ApsTreeItem)._apsId"
-        expanded-icon="i-lucide-folder-open"
-        collapsed-icon="i-lucide-folder"
-        color="neutral"
-        @toggle="onToggle"
-        @select="onSelect"
-      >
-        <template #loading-leading>
-          <UIcon name="i-lucide-loader" class="animate-spin shrink-0" />
-        </template>
-        <template #project-trailing="{ item }">
-          <div @click.stop>
-            <UButton
-              size="xs"
-              variant="ghost"
-              color="neutral"
-              icon="i-lucide-file-search"
-              class="whitespace-nowrap"
-              :loading="searchingProject === (item as ApsTreeItem)._projectId"
-              @click="onSearchRevitFiles(item as ApsTreeItem)"
-            >
-              {{ searchingProject === (item as ApsTreeItem)._projectId ? 'Scanning...' : 'Find .rvt' }}
-            </UButton>
-          </div>
-        </template>
-        <template #item-trailing="{ item }">
-          <template v-if="isRvtItem(item as ApsTreeItem)">
-            <UBadge
-              size="sm"
-              color="success"
-              variant="subtle"
-            >
-              RVT
-            </UBadge>
-            <div @click.stop>
+      <div v-if="!loading" ref="treeContainer">
+        <UTree
+          v-model:expanded="expandedKeys"
+          :items="filteredItems"
+          :get-key="(item: TreeItem) => (item as ApsTreeItem)._apsId"
+          expanded-icon="i-lucide-folder-open"
+          collapsed-icon="i-lucide-folder"
+          color="neutral"
+          @toggle="onToggle"
+          @select="onSelect"
+        >
+          <template #loading-leading>
+            <UIcon name="i-lucide-loader" class="animate-spin shrink-0" />
+          </template>
+          <template #project-trailing="{ item }">
+            <span :data-aps-id="(item as ApsTreeItem)._apsId" class="hidden" aria-hidden="true" />
+            <div class="flex items-center" @click.stop>
               <UButton
                 size="xs"
                 variant="ghost"
                 color="neutral"
-                icon="i-lucide-external-link"
-                :to="getAccUrl(item as ApsTreeItem)"
-                target="_blank"
-              />
-            </div>
-            <div @click.stop>
-              <UCheckbox
-                :model-value="isFileSelected(getItemId(item as ApsTreeItem))"
-                size="sm"
-                @update:model-value="toggleFile(
-                  getItemId(item as ApsTreeItem),
-                  (item as ApsTreeItem)._projectId || '',
-                  (item as ApsTreeItem).label || '',
-                  (item as ApsTreeItem)._region
-                )"
-              />
+                icon="i-lucide-file-search"
+                class="whitespace-nowrap"
+                :loading="searchingProject === (item as ApsTreeItem)._projectId"
+                @click="onSearchRevitFiles(item as ApsTreeItem)"
+              >
+                {{ searchingProject === (item as ApsTreeItem)._projectId ? 'Scanning...' : 'Find .rvt' }}
+              </UButton>
+              <UTooltip :text="isFavorite(item as ApsTreeItem) ? 'Remove from favorites' : 'Add to favorites'">
+                <UButton
+                  size="xs"
+                  variant="ghost"
+                  :color="isFavorite(item as ApsTreeItem) ? 'warning' : 'neutral'"
+                  icon="i-lucide-star"
+                  @click="toggleFavorite(item as ApsTreeItem)"
+                />
+              </UTooltip>
+              <UTooltip v-if="(item as ApsTreeItem)._folderId" text="Remove project">
+                <UButton
+                  size="xs"
+                  variant="ghost"
+                  color="neutral"
+                  icon="i-lucide-x"
+                  @click="removeExternalProject(item as ApsTreeItem)"
+                />
+              </UTooltip>
             </div>
           </template>
-        </template>
-      </UTree>
+          <template #item-trailing="{ item }">
+            <template v-if="isRvtItem(item as ApsTreeItem)">
+              <UBadge
+                size="sm"
+                color="success"
+                variant="subtle"
+              >
+                RVT
+              </UBadge>
+              <div @click.stop>
+                <UButton
+                  size="xs"
+                  variant="ghost"
+                  color="neutral"
+                  icon="i-lucide-external-link"
+                  :to="getAccUrl(item as ApsTreeItem)"
+                  target="_blank"
+                />
+              </div>
+              <div @click.stop>
+                <UCheckbox
+                  :model-value="isFileSelected(getItemId(item as ApsTreeItem))"
+                  size="sm"
+                  @update:model-value="toggleFile(
+                    getItemId(item as ApsTreeItem),
+                    (item as ApsTreeItem)._projectId || '',
+                    (item as ApsTreeItem).label || '',
+                    (item as ApsTreeItem)._region,
+                    (item as ApsTreeItem)._projectName
+                  )"
+                />
+              </div>
+            </template>
+          </template>
+        </UTree>
+      </div>
     </div>
 
     <!-- Collapsible search results -->

--- a/app/app/components/DerivativeSelector.vue
+++ b/app/app/components/DerivativeSelector.vue
@@ -16,26 +16,35 @@ const emit = defineEmits<{
 }>()
 
 const search = ref('')
-const activeFormatFilter = ref<DerivativeFormat | null>('pdf')
+const advancedOpen = ref(false)
+const activeFormatFilter = ref<DerivativeFormat | null>(null)
 
-const availableFormats = computed(() => getFormatCounts(props.derivatives))
+const pdfDerivatives = computed(() => props.derivatives.filter(d => d.format === 'pdf'))
+const advancedDerivatives = computed(() => props.derivatives.filter(d => d.format !== 'pdf'))
 
-const filteredDerivatives = computed(() => {
-  let list = props.derivatives
+const availableFormats = computed(() => getFormatCounts(advancedDerivatives.value))
+
+function applySearch(list: Derivative[]) {
+  if (!search.value) return list
+  const q = search.value.toLowerCase()
+  return list.filter(d => d.name.toLowerCase().includes(q))
+}
+
+const filteredPdfs = computed(() => applySearch(pdfDerivatives.value))
+
+const filteredAdvanced = computed(() => {
+  let list = advancedDerivatives.value
   if (activeFormatFilter.value) {
     list = list.filter(d => d.format === activeFormatFilter.value)
   }
-  if (search.value) {
-    const q = search.value.toLowerCase()
-    list = list.filter(d => d.name.toLowerCase().includes(q))
-  }
-  return list
+  return applySearch(list)
 })
 
-const filteredGuids = computed(() => filteredDerivatives.value.map(d => d.guid))
+const filteredPdfGuids = computed(() => filteredPdfs.value.map(d => d.guid))
+const filteredAdvancedGuids = computed(() => filteredAdvanced.value.map(d => d.guid))
 
-const selectedCount = computed(() =>
-  props.derivatives.filter(d => d.active).length
+const selectedPdfCount = computed(() =>
+  pdfDerivatives.value.filter(d => d.active).length
 )
 
 function toggleFormatFilter(format: DerivativeFormat) {
@@ -70,42 +79,24 @@ const virtualizeOptions = { estimateSize: () => 28, skipMeasurement: true, overs
     <div class="flex items-center gap-2">
       <UInput
         v-model="search"
-        placeholder="Filter derivatives..."
+        placeholder="Filter sheets..."
         icon="i-lucide-search"
         size="sm"
         class="flex-1"
       />
       <UBadge color="primary" variant="subtle">
-        {{ selectedCount }} / {{ derivatives.length }}
+        {{ selectedPdfCount }} / {{ pdfDerivatives.length }}
       </UBadge>
     </div>
 
-    <div v-if="availableFormats.length > 1" class="flex flex-wrap gap-1">
-      <UButton
-        size="xs"
-        :variant="activeFormatFilter === null ? 'solid' : 'subtle'"
-        :color="activeFormatFilter === null ? 'primary' : 'neutral'"
-        @click="activeFormatFilter = null"
-      >
-        All
-      </UButton>
-      <UButton
-        v-for="f in availableFormats"
-        :key="f.format"
-        size="xs"
-        :variant="activeFormatFilter === f.format ? 'solid' : 'subtle'"
-        :color="f.color"
-        @click="toggleFormatFilter(f.format)"
-      >
-        {{ f.count }} {{ f.label }}
-      </UButton>
-    </div>
-
-    <div v-if="viewSets.length > 1" class="flex flex-col gap-2">
+    <div class="flex flex-col gap-2">
       <p class="text-xs font-medium text-muted">
-        View Sets
+        Print Sets
       </p>
-      <div class="flex flex-wrap gap-2">
+      <p v-if="viewSets.length === 0" class="text-sm text-muted">
+        No published print sets found for this model.
+      </p>
+      <div v-else class="flex flex-wrap gap-2">
         <UCheckbox
           v-for="vs in viewSets"
           :key="vs.name"
@@ -120,14 +111,14 @@ const virtualizeOptions = { estimateSize: () => 28, skipMeasurement: true, overs
     <div class="flex flex-col gap-1">
       <div class="flex items-center justify-between">
         <p class="text-xs font-medium text-muted">
-          Derivatives
+          Sheets (PDF)
         </p>
-        <div class="flex items-center gap-1">
+        <div v-if="pdfDerivatives.length > 0" class="flex items-center gap-1">
           <UButton
             size="xs"
             variant="link"
             color="neutral"
-            @click="emit('selectAll', filteredGuids)"
+            @click="emit('selectAll', filteredPdfGuids)"
           >
             Select All
           </UButton>
@@ -135,18 +126,18 @@ const virtualizeOptions = { estimateSize: () => 28, skipMeasurement: true, overs
             size="xs"
             variant="link"
             color="neutral"
-            @click="emit('deselectAll', filteredGuids)"
+            @click="emit('deselectAll', filteredPdfGuids)"
           >
             Deselect All
           </UButton>
         </div>
       </div>
-      <p v-if="filteredDerivatives.length === 0" class="text-sm text-muted py-2">
-        No derivatives found
+      <p v-if="filteredPdfs.length === 0" class="text-sm text-muted py-2">
+        No PDF sheets found for this model
       </p>
       <UScrollArea
         v-else
-        :items="filteredDerivatives"
+        :items="filteredPdfs"
         :virtualize="virtualizeOptions"
         class="max-h-96"
       >
@@ -163,17 +154,9 @@ const virtualizeOptions = { estimateSize: () => 28, skipMeasurement: true, overs
               :ui="{ label: 'truncate' }"
               @update:model-value="emit('toggleDerivative', d.guid)"
             />
-            <UBadge
-              size="xs"
-              :color="FORMAT_COLORS[d.format]"
-              variant="subtle"
-              class="shrink-0"
-            >
-              {{ FORMAT_LABELS[d.format] }}
-            </UBadge>
-            <UTooltip :text="isPreviewable(d.format) ? 'Preview' : 'Download'">
+            <UTooltip text="Preview">
               <UButton
-                :icon="isPreviewable(d.format) ? 'i-lucide-eye' : 'i-lucide-download'"
+                icon="i-lucide-eye"
                 size="xs"
                 color="neutral"
                 variant="ghost"
@@ -185,5 +168,106 @@ const virtualizeOptions = { estimateSize: () => 28, skipMeasurement: true, overs
         </template>
       </UScrollArea>
     </div>
+
+    <UCollapsible v-if="advancedDerivatives.length > 0" v-model:open="advancedOpen">
+      <UButton
+        size="xs"
+        variant="link"
+        color="neutral"
+        :trailing-icon="advancedOpen ? 'i-lucide-chevron-up' : 'i-lucide-chevron-down'"
+        :label="`Show advanced model data (${advancedDerivatives.length})`"
+      />
+      <template #content>
+        <div class="flex flex-col gap-2 pt-2">
+          <div v-if="availableFormats.length > 1" class="flex flex-wrap gap-1">
+            <UButton
+              size="xs"
+              :variant="activeFormatFilter === null ? 'solid' : 'subtle'"
+              :color="activeFormatFilter === null ? 'primary' : 'neutral'"
+              @click="activeFormatFilter = null"
+            >
+              All
+            </UButton>
+            <UButton
+              v-for="f in availableFormats"
+              :key="f.format"
+              size="xs"
+              :variant="activeFormatFilter === f.format ? 'solid' : 'subtle'"
+              :color="f.color"
+              @click="toggleFormatFilter(f.format)"
+            >
+              {{ f.count }} {{ f.label }}
+            </UButton>
+          </div>
+
+          <div class="flex items-center justify-between">
+            <p class="text-xs font-medium text-muted">
+              Advanced Model Data
+            </p>
+            <div class="flex items-center gap-1">
+              <UButton
+                size="xs"
+                variant="link"
+                color="neutral"
+                @click="emit('selectAll', filteredAdvancedGuids)"
+              >
+                Select All
+              </UButton>
+              <UButton
+                size="xs"
+                variant="link"
+                color="neutral"
+                @click="emit('deselectAll', filteredAdvancedGuids)"
+              >
+                Deselect All
+              </UButton>
+            </div>
+          </div>
+          <p v-if="filteredAdvanced.length === 0" class="text-sm text-muted py-2">
+            No matching items
+          </p>
+          <UScrollArea
+            v-else
+            :items="filteredAdvanced"
+            :virtualize="virtualizeOptions"
+            class="max-h-96"
+          >
+            <template #default="{ item: d }">
+              <div
+                class="group flex items-center gap-2 rounded px-1 hover:bg-elevated"
+                style="height: 28px;"
+              >
+                <UCheckbox
+                  :model-value="d.active"
+                  :label="d.name"
+                  size="sm"
+                  class="flex-1 min-w-0"
+                  :ui="{ label: 'truncate' }"
+                  @update:model-value="emit('toggleDerivative', d.guid)"
+                />
+                <UBadge
+                  size="xs"
+                  :color="FORMAT_COLORS[d.format]"
+                  variant="subtle"
+                  class="shrink-0"
+                >
+                  {{ FORMAT_LABELS[d.format] }}
+                </UBadge>
+                <UTooltip :text="isPreviewable(d.format) ? 'Preview' : 'Download'">
+                  <UButton
+                    :icon="isPreviewable(d.format) ? 'i-lucide-eye' : 'i-lucide-download'"
+                    size="xs"
+                    color="neutral"
+                    variant="ghost"
+                    class="shrink-0"
+                    @click.stop="emit('preview', d.guid)"
+                  />
+                </UTooltip>
+              </div>
+            </template>
+          </UScrollArea>
+        </div>
+      </template>
+    </UCollapsible>
   </div>
 </template>

--- a/app/app/components/ExportButton.vue
+++ b/app/app/components/ExportButton.vue
@@ -19,12 +19,12 @@ const selectionIsPdfOnly = computed(() => {
 })
 
 const exportLabel = computed(() => {
-  if (exporting.value) return 'Exporting...'
+  if (exporting.value) return 'Preparing download...'
   const count = totalSelectedCount.value
   if (selectionIsPdfOnly.value) {
-    return `Export ${count} PDF${count === 1 ? '' : 's'}`
+    return `Download ${count} PDF${count === 1 ? '' : 's'}`
   }
-  return `Export ${count} file${count === 1 ? '' : 's'}`
+  return `Download ${count} file${count === 1 ? '' : 's'}`
 })
 </script>
 
@@ -91,7 +91,7 @@ const exportLabel = computed(() => {
       color="success"
       variant="subtle"
       icon="i-lucide-check-circle"
-      title="Export complete"
+      title="Download complete"
       description="Your download should start automatically."
     />
   </div>

--- a/app/app/components/SelectedFilesPanel.vue
+++ b/app/app/components/SelectedFilesPanel.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
+import { format } from 'date-fns'
 import type { AccordionItem } from '@nuxt/ui'
-import type { DerivativeFormat } from '~/types/derivatives'
-import { getFormatCounts } from '~/utils/derivative-formats'
+import type { Derivative, DerivativeFormat } from '~/types/derivatives'
 
 const {
   selectedFilesList,
@@ -56,6 +56,18 @@ function getAccFileUrl(itemId: string): string {
   if (!file) return '#'
   return buildAccProjectUrl(file.projectId, file.region, file.itemId)
 }
+
+function pdfCount(derivatives: Derivative[]): number {
+  return derivatives.filter(d => d.format === 'pdf').length
+}
+
+function lastPublished(itemId: string): string | null {
+  const t = fileState(itemId)?.lastModifiedTime
+  if (!t) return null
+  const parsed = Date.parse(t)
+  if (Number.isNaN(parsed)) return null
+  return format(new Date(parsed), 'PPp')
+}
 </script>
 
 <template>
@@ -85,6 +97,9 @@ function getAccFileUrl(itemId: string): string {
             @click.stop
           />
         </div>
+        <span v-if="lastPublished(item.value!)" class="text-xs text-muted">
+          Last published: {{ lastPublished(item.value!) }}
+        </span>
         <div class="flex flex-wrap gap-1 min-h-5">
           <template v-if="fileState(item.value!)?.loading">
             <USkeleton class="h-5 w-14 rounded-full" />
@@ -94,13 +109,19 @@ function getAccFileUrl(itemId: string): string {
           </template>
           <template v-else-if="fileState(item.value!)?.derivatives.length">
             <UBadge
-              v-for="fc in getFormatCounts(fileState(item.value!)!.derivatives)"
-              :key="fc.format"
               size="xs"
-              :color="fc.color"
+              color="primary"
               variant="subtle"
             >
-              {{ fc.count }} {{ fc.label }}
+              {{ pdfCount(fileState(item.value!)!.derivatives) }} PDF{{ pdfCount(fileState(item.value!)!.derivatives) === 1 ? '' : 's' }}
+            </UBadge>
+            <UBadge
+              v-if="fileState(item.value!)!.derivatives.length - pdfCount(fileState(item.value!)!.derivatives) > 0"
+              size="xs"
+              color="neutral"
+              variant="subtle"
+            >
+              +{{ fileState(item.value!)!.derivatives.length - pdfCount(fileState(item.value!)!.derivatives) }} advanced
             </UBadge>
           </template>
         </div>
@@ -149,10 +170,6 @@ function getAccFileUrl(itemId: string): string {
             icon="i-lucide-alert-triangle"
             :title="file.error"
           />
-        </div>
-
-        <div v-else-if="file.derivatives.length === 0" class="py-4 text-center text-sm text-muted">
-          No derivatives found in this model.
         </div>
 
         <div v-else>

--- a/app/app/components/__tests__/ApsProjectTree.test.ts
+++ b/app/app/components/__tests__/ApsProjectTree.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import type { ApsTreeItem } from '~/types/aps'
+import { filterProjectTree } from '~/utils/tree-filter'
 
 // Replicate the component's pure logic for testing
 function isRvtItem(item: ApsTreeItem): boolean {
@@ -64,61 +65,77 @@ function buildHubItem(): ApsTreeItem {
   }
 }
 
-// Replicate the component's filterTree function for testing
-function filterTree(nodes: ApsTreeItem[], query: string): ApsTreeItem[] {
-  if (!query) return nodes
-  const q = query.toLowerCase()
-  return nodes.reduce<ApsTreeItem[]>((acc, node) => {
-    const labelMatch = node.label?.toLowerCase().includes(q)
-    const filteredChildren = node.children ? filterTree(node.children, query) : []
-    if (labelMatch || filteredChildren.length > 0) {
-      acc.push({ ...node, children: filteredChildren.length > 0 ? filteredChildren : node.children })
-    }
-    return acc
-  }, [])
-}
-
-describe('filterTree', () => {
-  it('returns all items when query is empty', () => {
-    const items = [buildHubItem(), buildProjectItem()]
-    expect(filterTree(items, '')).toBe(items)
-  })
-
-  it('matches items by label substring (case-insensitive)', () => {
-    const items = [
-      buildHubItem(),
-      { ...buildProjectItem(), label: 'Alpha Project' },
-      { ...buildProjectItem(), label: 'Beta Project', _apsId: 'project-beta' }
-    ]
-    const result = filterTree(items, 'alpha')
-    expect(result).toHaveLength(1)
-    expect(result[0].label).toBe('Alpha Project')
-  })
-
-  it('preserves parent path to matching descendants', () => {
-    const hub: ApsTreeItem = {
+describe('filterProjectTree', () => {
+  function buildHubWithProjects(): ApsTreeItem {
+    return {
       ...buildHubItem(),
       children: [
-        {
-          ...buildProjectItem(),
-          label: 'Unrelated',
-          _apsId: 'project-unrelated',
-          children: [{ ...buildRvtItem(), label: 'DeepMatch.rvt', _apsId: 'item-deep' }]
-        }
+        { ...buildProjectItem(), label: 'Alpha Project', _apsId: 'project-alpha' },
+        { ...buildProjectItem(), label: 'Beta Project', _apsId: 'project-beta' }
       ]
     }
-    const result = filterTree([hub], 'DeepMatch')
+  }
+
+  it('returns all items when query is empty', () => {
+    const items = [buildHubWithProjects()]
+    expect(filterProjectTree(items, '')).toBe(items)
+  })
+
+  it('matches projects by label substring (case-insensitive)', () => {
+    const result = filterProjectTree([buildHubWithProjects()], 'ALPHA')
     expect(result).toHaveLength(1)
-    expect(result[0].label).toBe('My Hub')
-    expect(result[0].children).toHaveLength(1)
-    expect(result[0].children![0].label).toBe('Unrelated')
-    expect(result[0].children![0].children).toHaveLength(1)
-    expect(result[0].children![0].children![0].label).toBe('DeepMatch.rvt')
+    expect(result[0]!.children).toHaveLength(1)
+    expect(result[0]!.children![0]!.label).toBe('Alpha Project')
+  })
+
+  it('matched projects keep their original children (normal folder tree on expand)', () => {
+    const project = {
+      ...buildProjectItem(),
+      label: 'Alpha Project',
+      _apsId: 'project-alpha',
+      children: [buildFolderItem()]
+    }
+    const hub = { ...buildHubItem(), children: [project] }
+    const result = filterProjectTree([hub], 'alpha')
+    expect(result[0]!.children![0]!.children).toBe(project.children)
+  })
+
+  it('does not match nested folder or file labels', () => {
+    const project = {
+      ...buildProjectItem(),
+      label: 'Unrelated',
+      _apsId: 'project-unrelated',
+      children: [
+        { ...buildFolderItem(), label: 'DeepMatch Folder' },
+        { ...buildRvtItem(), label: 'DeepMatch.rvt', _apsId: 'item-deep' }
+      ]
+    }
+    const hub = { ...buildHubItem(), children: [project] }
+    expect(filterProjectTree([hub], 'DeepMatch')).toEqual([])
+  })
+
+  it('hub label match keeps the original node with all projects', () => {
+    const hub = buildHubWithProjects()
+    const result = filterProjectTree([hub], 'my hub')
+    expect(result).toHaveLength(1)
+    expect(result[0]).toBe(hub)
+  })
+
+  it('keeps unexpanded hubs (loading placeholder children)', () => {
+    const hub: ApsTreeItem = {
+      ...buildHubItem(),
+      label: 'Other Hub',
+      children: [{ label: 'Loading...', _apsType: 'loading', _apsId: 'loading-hub' }]
+    }
+    const result = filterProjectTree([hub], 'alpha')
+    expect(result).toHaveLength(1)
+    expect(result[0]).toBe(hub)
   })
 
   it('returns empty array when nothing matches', () => {
-    const items = [buildHubItem(), buildProjectItem()]
-    expect(filterTree(items, 'zzz-no-match')).toEqual([])
+    const hub = buildHubWithProjects()
+    hub.label = 'Loaded Hub'
+    expect(filterProjectTree([hub], 'zzz-no-match')).toEqual([])
   })
 })
 

--- a/app/app/components/__tests__/tree-lazy-load.test.ts
+++ b/app/app/components/__tests__/tree-lazy-load.test.ts
@@ -1,0 +1,75 @@
+// Regression test for the "first expand hangs on Loading..." bug.
+//
+// UTree renders nested branches by reading `item.children` on plain node
+// objects; a branch only re-renders when that in-place mutation is reactive.
+// The tree ref MUST therefore be a deep ref — with a shallowRef, children
+// committed by findAndReplaceChildren never appear until the branch is
+// collapsed and re-expanded. These tests pin the mechanism.
+import { describe, it, expect } from 'vitest'
+import { ref, shallowRef, computed } from 'vue'
+import type { Ref } from 'vue'
+import { findAndReplaceChildren } from '~/composables/useApsProjects'
+import type { ApsTreeItem } from '~/types/aps'
+
+function makeTree(): ApsTreeItem[] {
+  return [{
+    label: 'Alpha Project',
+    _apsType: 'project',
+    _apsId: 'project-alpha',
+    _projectId: 'alpha',
+    children: [{
+      label: 'Loading...',
+      disabled: true,
+      _apsType: 'loading',
+      _apsId: 'loading-project-alpha'
+    }]
+  }]
+}
+
+const loadedChildren: ApsTreeItem[] = [
+  { label: 'Project Files', _apsType: 'folder', _apsId: 'folder-1' }
+]
+
+// Simulates what UTree's nested branch template reads during render
+function renderBranch(items: ApsTreeItem[]): string[] {
+  return items[0]!.children?.map(c => c.label || '') ?? []
+}
+
+describe('lazy-loaded tree children reactivity (first expand)', () => {
+  it('committed children are visible through a deep ref without reassigning items.value', () => {
+    const items = ref<ApsTreeItem[]>(makeTree()) as Ref<ApsTreeItem[]>
+    const branch = computed(() => renderBranch(items.value))
+
+    expect(branch.value).toEqual(['Loading...'])
+
+    findAndReplaceChildren(items.value, 'project-alpha', loadedChildren)
+
+    // No items.value reassignment — the render must react to the nested
+    // mutation alone, exactly like UTree's expanded branch does
+    expect(branch.value).toEqual(['Project Files'])
+  })
+
+  it('documents the shallowRef failure mode this guards against', () => {
+    const items = shallowRef<ApsTreeItem[]>(makeTree())
+    const branch = computed(() => renderBranch(items.value))
+
+    expect(branch.value).toEqual(['Loading...'])
+
+    findAndReplaceChildren(items.value, 'project-alpha', loadedChildren)
+
+    // Stale: the computed (≈ the rendered branch) never saw the commit.
+    // If this assertion ever starts failing, Vue semantics changed and the
+    // deep-ref requirement in useApsProjects can be revisited.
+    expect(branch.value).toEqual(['Loading...'])
+  })
+
+  it('findAndReplaceChildren marks the parent loaded and replaces nested targets', () => {
+    const items = makeTree()
+    const found = findAndReplaceChildren(items, 'project-alpha', loadedChildren)
+
+    expect(found).toBe(true)
+    expect(items[0]!._loaded).toBe(true)
+    expect(items[0]!.children).toBe(loadedChildren)
+    expect(findAndReplaceChildren(items, 'missing-id', [])).toBe(false)
+  })
+})

--- a/app/app/composables/useApsProjects.ts
+++ b/app/app/composables/useApsProjects.ts
@@ -1,4 +1,14 @@
+import type { Ref } from 'vue'
 import type { ApsTreeItem, ApsRevitFile, RevitFileSSEEvent } from '~/types/aps'
+import type { StoredExternalProject } from '~/utils/external-projects'
+import {
+  upsertStoredExternalProject,
+  removeStoredExternalProject,
+  buildStoredExternalProjectNode
+} from '~/utils/external-projects'
+import type { FavoriteProject } from '~/utils/favorites'
+import { isFavorited, toggleFavoriteInList } from '~/utils/favorites'
+import { shouldLoadChildren } from '~/utils/tree-loading'
 
 function makeLoadingPlaceholder(parentId: string): ApsTreeItem {
   return {
@@ -11,7 +21,7 @@ function makeLoadingPlaceholder(parentId: string): ApsTreeItem {
   }
 }
 
-function findAndReplaceChildren(items: ApsTreeItem[], parentId: string, newChildren: ApsTreeItem[]): boolean {
+export function findAndReplaceChildren(items: ApsTreeItem[], parentId: string, newChildren: ApsTreeItem[]): boolean {
   for (const item of items) {
     if (item._apsId === parentId) {
       if (newChildren.length === 0) {
@@ -31,8 +41,19 @@ function findAndReplaceChildren(items: ApsTreeItem[], parentId: string, newChild
 }
 
 export function useApsProjects() {
-  const items = ref<ApsTreeItem[]>([])
+  // MUST be a deep ref: UTree's nested branches only re-render when the
+  // in-place child mutations (findAndReplaceChildren) are reactive — a
+  // shallowRef here makes lazily loaded children invisible until the branch
+  // is collapsed/re-expanded. The `as Ref` cast stops TypeScript from
+  // recursing into UnwrapRef on the recursive tree type (TS2589).
+  const items = ref<ApsTreeItem[]>([]) as Ref<ApsTreeItem[]>
+
+  const expandedKeys = ref<string[]>([])
   const loading = ref(false)
+  // Client-only metadata so added hubs/projects survive reloads; no auth material
+  const storedExternalProjects = useLocalStorage<StoredExternalProject[]>('sprint:external-projects', [])
+  const storedManualHubs = useLocalStorage<string[]>('sprint:manual-hubs', [])
+  const favoriteProjects = useLocalStorage<FavoriteProject[]>('sprint:favorite-projects', [])
   const warnings = ref<string[]>([])
   const searchingProject = ref<string | null>(null)
   const searchProgress = ref('')
@@ -42,6 +63,7 @@ export function useApsProjects() {
   async function loadHubs() {
     loading.value = true
     warnings.value = []
+    expandedKeys.value = []
     try {
       const response = await $fetch('/api/aps/hubs')
       warnings.value = response.warnings || []
@@ -75,6 +97,7 @@ export function useApsProjects() {
       _hubId: hubId,
       _projectId: project.id,
       _region: item._region,
+      _projectName: project.name,
       children: [makeLoadingPlaceholder(`project-${project.id}`)]
     })).sort((a, b) => (a.label ?? '').localeCompare(b.label ?? ''))
 
@@ -95,6 +118,7 @@ export function useApsProjects() {
       _hubId: hubId,
       _projectId: projectId,
       _region: item._region,
+      _projectName: item._projectName ?? item.label,
       children: [makeLoadingPlaceholder(`folder-${folder.id}`)]
     }))
 
@@ -102,7 +126,7 @@ export function useApsProjects() {
     items.value = [...items.value]
   }
 
-  async function loadFolderContents(item: ApsTreeItem) {
+  async function loadFolderContents(item: ApsTreeItem, replaceTargetId?: string) {
     const projectId = item._projectId
     const folderId = item._apsId.replace('folder-', '')
     if (!projectId) return
@@ -117,6 +141,7 @@ export function useApsProjects() {
           _hubId: item._hubId,
           _projectId: projectId,
           _region: item._region,
+          _projectName: item._projectName,
           children: [makeLoadingPlaceholder(`folder-${content.id}`)]
         }
       }
@@ -126,19 +151,21 @@ export function useApsProjects() {
         _apsType: 'item',
         _apsId: `item-${content.id}`,
         _projectId: projectId,
-        _region: item._region
+        _region: item._region,
+        _projectName: item._projectName
       }
     })
 
-    findAndReplaceChildren(items.value, item._apsId, children.length > 0 ? children : [])
+    findAndReplaceChildren(items.value, replaceTargetId ?? item._apsId, children.length > 0 ? children : [])
     items.value = [...items.value]
   }
 
-  async function handleToggle(item: ApsTreeItem, isExpanded: boolean) {
-    // reka-ui reports isExpanded as the state BEFORE the toggle,
-    // so isExpanded=false means the user is expanding the node
-    if (isExpanded || item._loaded) return
+  async function handleToggle(item: ApsTreeItem) {
+    // Loads on any toggle of an unloaded node — see shouldLoadChildren for
+    // why the toggle direction is ignored. _loading dedupes concurrent calls.
+    if (!shouldLoadChildren(item)) return
 
+    item._loading = true
     try {
       switch (item._apsType) {
         case 'hub':
@@ -149,7 +176,7 @@ export function useApsProjects() {
         case 'project':
           // External projects already have children loaded, but if not, use folder contents
           if (item._folderId) {
-            await loadFolderContents({ ...item, _apsId: `folder-${item._folderId}` })
+            await loadFolderContents({ ...item, _apsId: `folder-${item._folderId}` }, item._apsId)
           } else {
             await loadTopFolders(item)
           }
@@ -160,14 +187,28 @@ export function useApsProjects() {
       }
     } catch {
       findAndReplaceChildren(items.value, item._apsId, [{
-        label: 'Failed to load',
+        label: 'Failed to load — collapse and expand to retry',
         icon: 'i-lucide-alert-circle',
         disabled: true,
         _apsType: 'loading',
         _apsId: `error-${item._apsId}`
       }])
+      // findAndReplaceChildren marks the node loaded; undo so the next
+      // toggle retries instead of hanging on the error placeholder
+      item._loaded = false
       items.value = [...items.value]
+    } finally {
+      item._loading = false
     }
+  }
+
+  async function expandNode(node: ApsTreeItem) {
+    if (!expandedKeys.value.includes(node._apsId)) {
+      expandedKeys.value = [...expandedKeys.value, node._apsId]
+    }
+    // Programmatic expansion does not fire the tree's @toggle,
+    // so trigger lazy loading manually
+    if (!node._loaded) await handleToggle(node)
   }
 
   function searchRevitFiles(hubId: string | undefined, projectId: string, folderId?: string) {
@@ -232,7 +273,12 @@ export function useApsProjects() {
       _hubId: id,
       children: [makeLoadingPlaceholder(`hub-${id}`)]
     }
-    items.value = [node]
+    if (!items.value.some(i => i._apsId === node._apsId)) {
+      items.value = [...items.value, node]
+    }
+    storedManualHubs.value = [...new Set([...storedManualHubs.value, id])]
+    expandNode(node)
+    return node
   }
 
   function parseBim360Url(url: string): { projectId: string, folderId: string } | null {
@@ -254,6 +300,7 @@ export function useApsProjects() {
           _apsType: 'folder',
           _apsId: `folder-${content.id}`,
           _projectId: parsed.projectId,
+          _projectName: response.folderName,
           children: [makeLoadingPlaceholder(`folder-${content.id}`)]
         }
       }
@@ -262,7 +309,8 @@ export function useApsProjects() {
         icon: content.isRevitFile ? 'i-lucide-file-box' : 'i-lucide-file',
         _apsType: 'item',
         _apsId: `item-${content.id}`,
-        _projectId: parsed.projectId
+        _projectId: parsed.projectId,
+        _projectName: response.folderName
       }
     })
 
@@ -274,6 +322,7 @@ export function useApsProjects() {
       _apsId: `project-${parsed.projectId}-${parsed.folderId}`,
       _projectId: parsed.projectId,
       _folderId: parsed.folderId,
+      _projectName: response.folderName,
       _loaded: true,
       children
     }
@@ -286,22 +335,148 @@ export function useApsProjects() {
         existingHub.children = [...(existingHub.children || []).filter(c => c._apsType !== 'loading'), projectNode]
       }
     } else {
-      const externalHub: ApsTreeItem = {
-        label: 'External Projects',
-        icon: 'i-lucide-globe',
-        _apsType: 'hub',
-        _apsId: externalHubId,
-        _hubId: 'external',
-        _loaded: true,
-        children: [projectNode]
+      items.value = [...items.value, makeExternalHubNode([projectNode])]
+    }
+    items.value = [...items.value]
+
+    // Show the new project immediately — children are already loaded
+    for (const key of [externalHubId, projectNode._apsId]) {
+      if (!expandedKeys.value.includes(key)) {
+        expandedKeys.value = [...expandedKeys.value, key]
       }
-      items.value = [...items.value, externalHub]
+    }
+
+    storedExternalProjects.value = upsertStoredExternalProject(storedExternalProjects.value, {
+      projectId: parsed.projectId,
+      folderId: parsed.folderId,
+      name: response.folderName
+    })
+  }
+
+  function makeExternalHubNode(children: ApsTreeItem[]): ApsTreeItem {
+    return {
+      label: 'External Projects',
+      icon: 'i-lucide-globe',
+      _apsType: 'hub',
+      _apsId: 'hub-external',
+      _hubId: 'external',
+      _loaded: true,
+      children
+    }
+  }
+
+  /**
+   * Restores saved manual hubs and external projects after loadHubs()
+   * replaced the tree. Builds lazy nodes only — no API calls.
+   */
+  function rehydrateStored() {
+    try {
+      for (const id of storedManualHubs.value) {
+        if (typeof id !== 'string' || !id) continue
+        const apsId = `hub-${id}`
+        if (items.value.some(i => i._apsId === apsId)) continue
+        items.value = [...items.value, {
+          label: `Hub (${id})`,
+          icon: 'i-lucide-building-2',
+          _apsType: 'hub',
+          _apsId: apsId,
+          _hubId: id,
+          children: [makeLoadingPlaceholder(apsId)]
+        }]
+      }
+
+      const projectNodes = storedExternalProjects.value
+        .filter(p => p && p.projectId && p.folderId)
+        .map(buildStoredExternalProjectNode)
+      if (projectNodes.length > 0) {
+        let hub = items.value.find(i => i._apsId === 'hub-external')
+        if (!hub) {
+          hub = makeExternalHubNode([])
+          items.value = [...items.value, hub]
+        }
+        for (const node of projectNodes) {
+          if (!hub.children?.some(c => c._apsId === node._apsId)) {
+            hub.children = [...(hub.children || []).filter(c => c._apsType !== 'loading'), node]
+          }
+        }
+      }
+      items.value = [...items.value]
+    } catch (error) {
+      console.error('Failed to restore saved hubs/projects:', error)
+    }
+  }
+
+  function findNode(nodes: ApsTreeItem[], apsId: string): ApsTreeItem | undefined {
+    for (const node of nodes) {
+      if (node._apsId === apsId) return node
+      const found = node.children && findNode(node.children, apsId)
+      if (found) return found
+    }
+    return undefined
+  }
+
+  function favoriteApsId(f: FavoriteProject): string {
+    return f.folderId ? `project-${f.projectId}-${f.folderId}` : `project-${f.projectId}`
+  }
+
+  function toggleFavorite(node: ApsTreeItem) {
+    if (!node._projectId) return
+    favoriteProjects.value = toggleFavoriteInList(favoriteProjects.value, {
+      projectId: node._projectId,
+      hubId: node._hubId,
+      folderId: node._folderId,
+      label: node.label || node._projectId,
+      region: node._region
+    })
+  }
+
+  function isFavorite(node: ApsTreeItem): boolean {
+    if (!node._projectId) return false
+    return isFavorited(favoriteProjects.value, { projectId: node._projectId, folderId: node._folderId })
+  }
+
+  /**
+   * Expands the tree down to a favorited project, loading the hub's
+   * projects on the way if needed. Returns the project node's key so the
+   * caller can scroll/highlight it, or null if it can't be reached.
+   */
+  async function openFavorite(f: FavoriteProject): Promise<string | null> {
+    const targetId = favoriteApsId(f)
+    // External projects live under the synthetic external hub
+    const hubKey = f.folderId ? 'hub-external' : f.hubId ? `hub-${f.hubId}` : null
+
+    let node = findNode(items.value, targetId)
+    if (!node && hubKey) {
+      const hub = findNode(items.value, hubKey)
+      if (hub) await expandNode(hub)
+      node = findNode(items.value, targetId)
+    }
+    if (!node) return null
+
+    // Hub must be expanded for the project row to be visible, even when
+    // the project node was already loaded
+    if (hubKey && !expandedKeys.value.includes(hubKey)) {
+      expandedKeys.value = [...expandedKeys.value, hubKey]
+    }
+    await expandNode(node)
+    return node._apsId
+  }
+
+  function removeExternalProject(node: ApsTreeItem) {
+    storedExternalProjects.value = removeStoredExternalProject(storedExternalProjects.value, node._apsId)
+    const hub = items.value.find(i => i._apsId === 'hub-external')
+    if (hub) {
+      hub.children = (hub.children || []).filter(c => c._apsId !== node._apsId)
+      if (hub.children.length === 0) {
+        items.value = items.value.filter(i => i._apsId !== 'hub-external')
+      }
     }
     items.value = [...items.value]
   }
 
   return {
     items,
+    expandedKeys,
     loading,
     warnings,
     searchingProject,
@@ -310,8 +485,15 @@ export function useApsProjects() {
     scannedFolders,
     loadHubs,
     handleToggle,
+    expandNode,
     searchRevitFiles,
     addManualHub,
-    addExternalProject
+    addExternalProject,
+    rehydrateStored,
+    removeExternalProject,
+    favoriteProjects,
+    toggleFavorite,
+    isFavorite,
+    openFavorite
   }
 }

--- a/app/app/composables/useDerivatives.ts
+++ b/app/app/composables/useDerivatives.ts
@@ -23,12 +23,13 @@ export function useDerivatives() {
 
   const hasSelections = computed(() => totalSelectedCount.value > 0)
 
-  async function addFile(itemId: string, projectId: string, name: string, region?: string) {
+  async function addFile(itemId: string, projectId: string, name: string, region?: string, projectName?: string) {
     if (selectedFiles.has(itemId)) return
 
     selectedFiles.set(itemId, {
       itemId,
       projectId,
+      projectName,
       name,
       urn: '',
       region,
@@ -49,6 +50,7 @@ export function useDerivatives() {
       if (!entry) return
       entry.urn = itemResult.urn
       entry.name = itemResult.name || name
+      entry.lastModifiedTime = itemResult.lastModifiedTime
 
       const manifestResult = await $fetch('/api/aps/manifest', {
         params: { urn: itemResult.urn, region }
@@ -59,7 +61,9 @@ export function useDerivatives() {
       entry.revitVersion = manifestResult.revitVersion
       entry.revitVersionSupported = manifestResult.revitVersionSupported
 
-      if (!manifestResult.revitVersionSupported) {
+      // Only flag unsupported versions when there is content; an empty
+      // manifest (nothing published) should show the empty state instead
+      if (!manifestResult.revitVersionSupported && manifestResult.derivatives.length > 0) {
         entry.error = `Revit version ${manifestResult.revitVersion || 'unknown'} is not supported. Requires 2022 or later.`
       }
     } catch (e: unknown) {
@@ -83,11 +87,11 @@ export function useDerivatives() {
     return selectedFiles.has(itemId)
   }
 
-  function toggleFile(itemId: string, projectId: string, name: string, region?: string) {
+  function toggleFile(itemId: string, projectId: string, name: string, region?: string, projectName?: string) {
     if (selectedFiles.has(itemId)) {
       removeFile(itemId)
     } else {
-      addFile(itemId, projectId, name, region)
+      addFile(itemId, projectId, name, region, projectName)
     }
   }
 
@@ -137,11 +141,14 @@ export function useDerivatives() {
       .map(file => ({
         urn: file.urn,
         derivatives: file.derivatives.filter(d => d.active).map(d => ({ urn: d.urn, name: d.name })),
-        name: file.name.replace(/\.rvt$/i, '')
+        name: file.name.replace(/\.rvt$/i, ''),
+        projectName: file.projectName
       }))
       .filter(f => f.derivatives.length > 0)
 
     if (filesToExport.length === 0) return
+
+    const downloadBaseName = computeDownloadBaseName(filesToExport)
 
     exporting.value = true
     exportError.value = null
@@ -167,6 +174,7 @@ export function useDerivatives() {
         body: JSON.stringify({
           files: filesToExport,
           region: exportRegion,
+          filename: downloadBaseName,
           options: { mergeScope: exportOptions.mergeScope, zip: exportOptions.zip, modelFolders: exportOptions.modelFolders }
         })
       })
@@ -176,20 +184,19 @@ export function useDerivatives() {
         return
       }
       if (!response.ok) {
-        throw new Error(`Export failed: ${response.statusText}`)
+        throw new Error(`Download failed: ${response.statusText}`)
       }
       const blob = await response.blob()
       const url = URL.createObjectURL(blob)
       const a = document.createElement('a')
       a.href = url
       const contentType = response.headers.get('Content-Type') || ''
-      let filename = 'derivatives.zip'
+      // Client-computed name wins (avoids non-ASCII header issues);
+      // Content-Disposition is the fallback for unexpected content types
+      let filename = `${downloadBaseName}.zip`
       if (contentType.includes('application/pdf')) {
-        filename = 'derivatives.pdf'
-      } else if (contentType.includes('application/zip')) {
-        filename = 'derivatives.zip'
-      } else {
-        // Extract filename from Content-Disposition if available
+        filename = `${downloadBaseName}.pdf`
+      } else if (!contentType.includes('application/zip')) {
         const disposition = response.headers.get('Content-Disposition') || ''
         const match = disposition.match(/filename="?([^";\s]+)"?/)
         if (match) filename = match[1]!
@@ -206,9 +213,9 @@ export function useDerivatives() {
         format: contentType.includes('application/pdf') ? 'pdf' : 'zip'
       })
     } catch (e: unknown) {
-      exportError.value = e instanceof Error ? e.message : 'Export failed'
+      exportError.value = e instanceof Error ? e.message : 'Download failed'
       posthog?.capture('export_failed', {
-        error: e instanceof Error ? e.message : 'Export failed'
+        error: e instanceof Error ? e.message : 'Download failed'
       })
     } finally {
       exporting.value = false

--- a/app/app/pages/dashboard.vue
+++ b/app/app/pages/dashboard.vue
@@ -46,12 +46,12 @@ definePageMeta({
           </UBadge>
         </template>
         <template #trailing>
-          <UTooltip v-if="selectedFilesList.length > 0" text="Clear all">
+          <UTooltip v-if="selectedFilesList.length > 0" text="Clear selection">
             <UButton
-              icon="i-lucide-trash-2"
+              icon="i-lucide-eraser"
               size="xs"
               variant="ghost"
-              color="error"
+              color="neutral"
               @click="clearAll"
             />
           </UTooltip>

--- a/app/app/types/aps.d.ts
+++ b/app/app/types/aps.d.ts
@@ -34,7 +34,9 @@ export interface ApsTreeItem extends TreeItem {
   _hubId?: string
   _folderId?: string
   _region?: string
+  _projectName?: string
   _loaded?: boolean
+  _loading?: boolean
   children?: ApsTreeItem[]
 }
 

--- a/app/app/types/derivatives.d.ts
+++ b/app/app/types/derivatives.d.ts
@@ -52,9 +52,11 @@ export type PdfViewSet = ViewSet
 export interface SelectedFileState {
   itemId: string
   projectId: string
+  projectName?: string
   name: string
   urn: string
   region?: string
+  lastModifiedTime?: string | null
   loading: boolean
   error: string | null
   derivatives: Derivative[]

--- a/app/app/utils/__tests__/download-name.test.ts
+++ b/app/app/utils/__tests__/download-name.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { computeDownloadBaseName, DEFAULT_DOWNLOAD_NAME } from '~/utils/download-name'
+
+describe('computeDownloadBaseName', () => {
+  it('uses the model name for a single file, stripping .rvt case-insensitively', () => {
+    expect(computeDownloadBaseName([{ name: 'Tower A.rvt' }])).toBe('Tower A')
+    expect(computeDownloadBaseName([{ name: 'Tower A.RVT' }])).toBe('Tower A')
+    expect(computeDownloadBaseName([{ name: 'Tower A' }])).toBe('Tower A')
+  })
+
+  it('falls back to default for a single file with an empty name', () => {
+    expect(computeDownloadBaseName([{ name: '.rvt' }])).toBe(DEFAULT_DOWNLOAD_NAME)
+    expect(computeDownloadBaseName([{ name: '  ' }])).toBe(DEFAULT_DOWNLOAD_NAME)
+  })
+
+  it('uses the project name when multiple files share a project', () => {
+    const files = [
+      { name: 'Tower A.rvt', projectName: 'Downtown Campus' },
+      { name: 'Tower B.rvt', projectName: 'Downtown Campus' }
+    ]
+    expect(computeDownloadBaseName(files)).toBe('Downtown Campus')
+  })
+
+  it('falls back to default when files span multiple projects', () => {
+    const files = [
+      { name: 'Tower A.rvt', projectName: 'Downtown Campus' },
+      { name: 'Clinic.rvt', projectName: 'Northside Clinic' }
+    ]
+    expect(computeDownloadBaseName(files)).toBe(DEFAULT_DOWNLOAD_NAME)
+  })
+
+  it('falls back to default when project names are missing on multiple files', () => {
+    const files = [{ name: 'A.rvt' }, { name: 'B.rvt' }]
+    expect(computeDownloadBaseName(files)).toBe(DEFAULT_DOWNLOAD_NAME)
+  })
+})

--- a/app/app/utils/__tests__/external-projects.test.ts
+++ b/app/app/utils/__tests__/external-projects.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+import {
+  externalProjectApsId,
+  upsertStoredExternalProject,
+  removeStoredExternalProject,
+  buildStoredExternalProjectNode
+} from '~/utils/external-projects'
+import type { StoredExternalProject } from '~/utils/external-projects'
+
+const project: StoredExternalProject = {
+  projectId: 'b.proj-1',
+  folderId: 'urn.folder.1',
+  name: 'Downtown Campus'
+}
+
+describe('upsertStoredExternalProject', () => {
+  it('adds a new project', () => {
+    expect(upsertStoredExternalProject([], project)).toEqual([project])
+  })
+
+  it('dedupes on projectId + folderId, keeping the latest entry', () => {
+    const updated = { ...project, name: 'Renamed' }
+    const result = upsertStoredExternalProject([project], updated)
+    expect(result).toHaveLength(1)
+    expect(result[0]!.name).toBe('Renamed')
+  })
+
+  it('keeps entries with a different folderId in the same project', () => {
+    const other = { ...project, folderId: 'urn.folder.2' }
+    expect(upsertStoredExternalProject([project], other)).toHaveLength(2)
+  })
+})
+
+describe('removeStoredExternalProject', () => {
+  it('removes by tree node aps id', () => {
+    const result = removeStoredExternalProject([project], externalProjectApsId(project))
+    expect(result).toEqual([])
+  })
+
+  it('leaves other entries untouched', () => {
+    const other = { ...project, folderId: 'urn.folder.2' }
+    const result = removeStoredExternalProject([project, other], externalProjectApsId(project))
+    expect(result).toEqual([other])
+  })
+})
+
+describe('buildStoredExternalProjectNode', () => {
+  it('builds a lazy project node with a loading placeholder', () => {
+    const node = buildStoredExternalProjectNode(project)
+    expect(node._apsId).toBe('project-b.proj-1-urn.folder.1')
+    expect(node._apsType).toBe('project')
+    expect(node._projectId).toBe('b.proj-1')
+    expect(node._folderId).toBe('urn.folder.1')
+    expect(node._projectName).toBe('Downtown Campus')
+    expect(node._loaded).toBe(false)
+    expect(node.children).toHaveLength(1)
+    expect(node.children![0]!._apsType).toBe('loading')
+  })
+})

--- a/app/app/utils/__tests__/favorites.test.ts
+++ b/app/app/utils/__tests__/favorites.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { isFavorited, toggleFavoriteInList } from '~/utils/favorites'
+import type { FavoriteProject } from '~/utils/favorites'
+
+const fav: FavoriteProject = { projectId: 'b.proj-1', hubId: 'b.hub-1', label: 'Downtown Campus' }
+
+describe('toggleFavoriteInList', () => {
+  it('adds when absent', () => {
+    expect(toggleFavoriteInList([], fav)).toEqual([fav])
+  })
+
+  it('removes when present', () => {
+    expect(toggleFavoriteInList([fav], fav)).toEqual([])
+  })
+
+  it('distinguishes external projects by folderId', () => {
+    const external = { ...fav, folderId: 'urn.folder.1' }
+    const list = toggleFavoriteInList([fav], external)
+    expect(list).toHaveLength(2)
+    expect(isFavorited(list, fav)).toBe(true)
+    expect(isFavorited(list, external)).toBe(true)
+  })
+})
+
+describe('isFavorited', () => {
+  it('matches on projectId when no folderId', () => {
+    expect(isFavorited([fav], { projectId: 'b.proj-1' })).toBe(true)
+    expect(isFavorited([fav], { projectId: 'b.proj-2' })).toBe(false)
+  })
+})

--- a/app/app/utils/__tests__/tree-loading.test.ts
+++ b/app/app/utils/__tests__/tree-loading.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import { shouldLoadChildren } from '~/utils/tree-loading'
+import type { ApsTreeItem } from '~/types/aps'
+
+function node(overrides: Partial<ApsTreeItem> = {}): ApsTreeItem {
+  return {
+    label: 'Test Project',
+    _apsType: 'project',
+    _apsId: 'project-proj-123',
+    _projectId: 'proj-123',
+    children: [{
+      label: 'Loading...',
+      disabled: true,
+      _apsType: 'loading',
+      _apsId: 'loading-project-proj-123'
+    }],
+    ...overrides
+  }
+}
+
+describe('shouldLoadChildren (first-expand lazy loading)', () => {
+  it('loads an unloaded project on first toggle, regardless of toggle direction', () => {
+    expect(shouldLoadChildren(node())).toBe(true)
+  })
+
+  it('loads unloaded hubs and folders', () => {
+    expect(shouldLoadChildren(node({ _apsType: 'hub' }))).toBe(true)
+    expect(shouldLoadChildren(node({ _apsType: 'folder' }))).toBe(true)
+  })
+
+  it('does not reload an already-loaded node', () => {
+    expect(shouldLoadChildren(node({ _loaded: true }))).toBe(false)
+  })
+
+  it('does not start a duplicate fetch while one is in flight', () => {
+    expect(shouldLoadChildren(node({ _loading: true }))).toBe(false)
+  })
+
+  it('never loads leaf or placeholder node types', () => {
+    expect(shouldLoadChildren(node({ _apsType: 'item' }))).toBe(false)
+    expect(shouldLoadChildren(node({ _apsType: 'loading' }))).toBe(false)
+  })
+
+  it('allows retry after a failed load (loaded reset, loading cleared)', () => {
+    // handleToggle's error path sets _loaded=false and _loading=false
+    expect(shouldLoadChildren(node({ _loaded: false, _loading: false }))).toBe(true)
+  })
+})

--- a/app/app/utils/derivative-formats.ts
+++ b/app/app/utils/derivative-formats.ts
@@ -5,10 +5,10 @@ export const FORMAT_LABELS: Record<DerivativeFormat, string> = {
   dwg: 'DWG',
   dwf: 'DWF',
   ifc: 'IFC',
-  thumbnail: 'Thumbnail',
-  aec: 'AEC Data',
-  sdb: 'SDB',
-  svf: 'SVF',
+  thumbnail: 'Thumbnails / Previews',
+  aec: 'Design Data (AEC)',
+  sdb: 'Model Data',
+  svf: '3D Views',
   other: 'Other'
 }
 

--- a/app/app/utils/download-name.ts
+++ b/app/app/utils/download-name.ts
@@ -1,0 +1,15 @@
+export const DEFAULT_DOWNLOAD_NAME = 'sPrint Download'
+
+/**
+ * Base name for a download: single model uses the Revit model name,
+ * multiple models from one project use the project name, anything else
+ * falls back to a generic name.
+ */
+export function computeDownloadBaseName(files: { name: string, projectName?: string }[]): string {
+  if (files.length === 1) {
+    return files[0]!.name.replace(/\.rvt$/i, '').trim() || DEFAULT_DOWNLOAD_NAME
+  }
+  const projects = new Set(files.map(f => f.projectName?.trim()).filter(Boolean))
+  if (projects.size === 1) return [...projects][0]!
+  return DEFAULT_DOWNLOAD_NAME
+}

--- a/app/app/utils/external-projects.ts
+++ b/app/app/utils/external-projects.ts
@@ -1,0 +1,57 @@
+import type { ApsTreeItem } from '~/types/aps'
+
+export interface StoredExternalProject {
+  projectId: string
+  folderId: string
+  name: string
+  region?: string
+}
+
+export function externalProjectApsId(p: Pick<StoredExternalProject, 'projectId' | 'folderId'>): string {
+  return `project-${p.projectId}-${p.folderId}`
+}
+
+export function upsertStoredExternalProject(
+  list: StoredExternalProject[],
+  project: StoredExternalProject
+): StoredExternalProject[] {
+  const withoutExisting = list.filter(
+    p => !(p.projectId === project.projectId && p.folderId === project.folderId)
+  )
+  return [...withoutExisting, project]
+}
+
+export function removeStoredExternalProject(
+  list: StoredExternalProject[],
+  apsId: string
+): StoredExternalProject[] {
+  return list.filter(p => externalProjectApsId(p) !== apsId)
+}
+
+/**
+ * Rebuilds a stored external project as a lazy tree node — contents load
+ * on expand via the normal folder-contents path, no API calls at startup.
+ */
+export function buildStoredExternalProjectNode(p: StoredExternalProject): ApsTreeItem {
+  const apsId = externalProjectApsId(p)
+  return {
+    label: p.name,
+    icon: 'i-lucide-folder-kanban',
+    slot: 'project' as const,
+    _apsType: 'project',
+    _apsId: apsId,
+    _projectId: p.projectId,
+    _folderId: p.folderId,
+    _region: p.region,
+    _projectName: p.name,
+    _loaded: false,
+    children: [{
+      label: 'Loading...',
+      icon: 'i-lucide-loader',
+      slot: 'loading',
+      disabled: true,
+      _apsType: 'loading',
+      _apsId: `loading-${apsId}`
+    }]
+  }
+}

--- a/app/app/utils/favorites.ts
+++ b/app/app/utils/favorites.ts
@@ -1,0 +1,22 @@
+export interface FavoriteProject {
+  projectId: string
+  hubId?: string
+  folderId?: string
+  label: string
+  region?: string
+}
+
+export function favoriteKey(f: Pick<FavoriteProject, 'projectId' | 'folderId'>): string {
+  return f.folderId ? `${f.projectId}:${f.folderId}` : f.projectId
+}
+
+export function isFavorited(list: FavoriteProject[], f: Pick<FavoriteProject, 'projectId' | 'folderId'>): boolean {
+  return list.some(p => favoriteKey(p) === favoriteKey(f))
+}
+
+export function toggleFavoriteInList(list: FavoriteProject[], f: FavoriteProject): FavoriteProject[] {
+  if (isFavorited(list, f)) {
+    return list.filter(p => favoriteKey(p) !== favoriteKey(f))
+  }
+  return [...list, f]
+}

--- a/app/app/utils/tree-filter.ts
+++ b/app/app/utils/tree-filter.ts
@@ -1,0 +1,32 @@
+import type { ApsTreeItem } from '~/types/aps'
+
+function isUnloadedHub(node: ApsTreeItem): boolean {
+  return !node.children?.length || node.children.every(c => c._apsType === 'loading')
+}
+
+/**
+ * Filters the project tree by hub/project names only. Nested folders and
+ * files never match, and matched projects keep their original children so
+ * expanding a match shows the normal folder tree.
+ */
+export function filterProjectTree(nodes: ApsTreeItem[], query: string): ApsTreeItem[] {
+  if (!query) return nodes
+  const q = query.toLowerCase()
+  return nodes.reduce<ApsTreeItem[]>((acc, node) => {
+    if (node._apsType === 'hub') {
+      if (node.label?.toLowerCase().includes(q) || isUnloadedHub(node)) {
+        acc.push(node)
+        return acc
+      }
+      const matchedProjects = (node.children ?? []).filter(
+        c => c._apsType === 'project' && c.label?.toLowerCase().includes(q)
+      )
+      if (matchedProjects.length > 0) {
+        acc.push({ ...node, children: matchedProjects })
+      }
+    } else if (node._apsType === 'project' && node.label?.toLowerCase().includes(q)) {
+      acc.push(node)
+    }
+    return acc
+  }, [])
+}

--- a/app/app/utils/tree-loading.ts
+++ b/app/app/utils/tree-loading.ts
@@ -1,0 +1,15 @@
+import type { ApsTreeItem } from '~/types/aps'
+
+const EXPANDABLE_TYPES = new Set(['hub', 'project', 'folder'])
+
+/**
+ * Whether a toggled tree node needs its children fetched. Direction of the
+ * toggle is deliberately ignored — reka-ui's toggle event reports expansion
+ * state with different semantics for controlled vs uncontrolled trees, which
+ * made first-expand loading hang. Loading is keyed purely off node state:
+ * not yet loaded, not currently loading, and of an expandable type.
+ */
+export function shouldLoadChildren(node: ApsTreeItem): boolean {
+  if (node._loaded || node._loading) return false
+  return EXPANDABLE_TYPES.has(node._apsType)
+}

--- a/app/package.json
+++ b/app/package.json
@@ -42,6 +42,7 @@
     "reka-ui": "2.7.0",
     "typescript": "^5.9.3",
     "vitest": "^4.1.2",
+    "vue": "^3.5.39",
     "vue-tsc": "^3.2.4"
   },
   "packageManager": "pnpm@10.30.1"

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
         version: 3.11.0
       '@nuxt/ui':
         specifier: ^4.4.0
-        version: 4.4.0(@tiptap/extensions@3.16.0(@tiptap/core@3.16.0(@tiptap/pm@3.16.0))(@tiptap/pm@3.16.0))(@tiptap/y-tiptap@3.0.1(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.5)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(change-case@5.4.4)(db0@0.3.4)(embla-carousel@8.6.0)(ioredis@5.10.1)(magicast@0.5.2)(tailwindcss@4.2.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))(vue-router@4.6.4(vue@3.5.31(typescript@5.9.3)))(vue@3.5.31(typescript@5.9.3))(yjs@13.6.29)(zod@4.3.6)
+        version: 4.4.0(@tiptap/extensions@3.16.0(@tiptap/core@3.16.0(@tiptap/pm@3.16.0))(@tiptap/pm@3.16.0))(@tiptap/y-tiptap@3.0.1(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.5)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(change-case@5.4.4)(db0@0.3.4)(embla-carousel@8.6.0)(ioredis@5.10.1)(magicast@0.5.2)(tailwindcss@4.2.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))(vue-router@4.6.4(vue@3.5.39(typescript@5.9.3)))(vue@3.5.39(typescript@5.9.3))(yjs@13.6.29)(zod@4.3.6)
       '@tanstack/table-core':
         specifier: ^8.21.3
         version: 8.21.3
@@ -28,13 +28,13 @@ importers:
         version: 1.6.4
       '@unovis/vue':
         specifier: ^1.6.4
-        version: 1.6.4(@unovis/ts@1.6.4)(vue@3.5.31(typescript@5.9.3))
+        version: 1.6.4(@unovis/ts@1.6.4)(vue@3.5.39(typescript@5.9.3))
       '@vueuse/core':
         specifier: ^14.2.1
-        version: 14.2.1(vue@3.5.31(typescript@5.9.3))
+        version: 14.2.1(vue@3.5.39(typescript@5.9.3))
       '@vueuse/nuxt':
         specifier: ^14.2.1
-        version: 14.2.1(magicast@0.5.2)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@parcel/watcher@2.5.6)(@types/node@25.2.2)(@vue/compiler-sfc@3.5.31)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.60.1))(rollup@4.60.1)(srvx@0.11.14)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))(vue-tsc@3.2.4(typescript@5.9.3))(yaml@2.8.3))(vue@3.5.31(typescript@5.9.3))
+        version: 14.2.1(magicast@0.5.2)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@parcel/watcher@2.5.6)(@types/node@25.2.2)(@vue/compiler-sfc@3.5.39)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.60.1))(rollup@4.60.1)(srvx@0.11.14)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))(vue-tsc@3.2.4(typescript@5.9.3))(yaml@2.8.3))(vue@3.5.39(typescript@5.9.3))
       archiver:
         specifier: ^7.0.1
         version: 7.0.1
@@ -43,10 +43,10 @@ importers:
         version: 4.1.0
       motion-v:
         specifier: ^1.10.3
-        version: 1.10.3(@vueuse/core@14.2.1(vue@3.5.31(typescript@5.9.3)))(vue@3.5.31(typescript@5.9.3))
+        version: 1.10.3(@vueuse/core@14.2.1(vue@3.5.39(typescript@5.9.3)))(vue@3.5.39(typescript@5.9.3))
       nuxt:
         specifier: ^4.4.2
-        version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@parcel/watcher@2.5.6)(@types/node@25.2.2)(@vue/compiler-sfc@3.5.31)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.60.1))(rollup@4.60.1)(srvx@0.11.14)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))(vue-tsc@3.2.4(typescript@5.9.3))(yaml@2.8.3)
+        version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@parcel/watcher@2.5.6)(@types/node@25.2.2)(@vue/compiler-sfc@3.5.39)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.60.1))(rollup@4.60.1)(srvx@0.11.14)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))(vue-tsc@3.2.4(typescript@5.9.3))(yaml@2.8.3)
       pdf-lib:
         specifier: ^1.17.1
         version: 1.17.1
@@ -65,7 +65,7 @@ importers:
     devDependencies:
       '@nuxt/eslint':
         specifier: ^1.15.1
-        version: 1.15.1(@typescript-eslint/utils@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.31)(eslint@9.39.2(jiti@2.6.1))(magicast@0.5.2)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 1.15.1(@typescript-eslint/utils@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.39)(eslint@9.39.2(jiti@2.6.1))(magicast@0.5.2)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))
       '@types/archiver':
         specifier: ^7.0.0
         version: 7.0.0
@@ -83,13 +83,16 @@ importers:
         version: 20.6.3
       reka-ui:
         specifier: 2.7.0
-        version: 2.7.0(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3))
+        version: 2.7.0(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3))
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vitest:
         specifier: ^4.1.2
         version: 4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.2.2)(happy-dom@20.6.3)(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))
+      vue:
+        specifier: ^3.5.39
+        version: 3.5.39(typescript@5.9.3)
       vue-tsc:
         specifier: ^3.2.4
         version: 3.2.4(typescript@5.9.3)
@@ -187,8 +190,16 @@ packages:
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-option@7.27.1':
@@ -199,18 +210,13 @@ packages:
     resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.28.6':
-    resolution: {integrity: sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
-  '@babel/parser@7.29.0':
-    resolution: {integrity: sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
   '@babel/parser@7.29.2':
     resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -248,12 +254,12 @@ packages:
     resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/types@7.28.6':
-    resolution: {integrity: sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
   '@bomb.sh/tab@0.0.14':
@@ -2864,23 +2870,29 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@vue/compiler-core@3.5.27':
-    resolution: {integrity: sha512-gnSBQjZA+//qDZen+6a2EdHqJ68Z7uybrMf3SPjEGgG4dicklwDVmMC1AeIHxtLVPT7sn6sH1KOO+tS6gwOUeQ==}
-
   '@vue/compiler-core@3.5.31':
     resolution: {integrity: sha512-k/ueL14aNIEy5Onf0OVzR8kiqF/WThgLdFhxwa4e/KF/0qe38IwIdofoSWBTvvxQOesaz6riAFAUaYjoF9fLLQ==}
 
-  '@vue/compiler-dom@3.5.27':
-    resolution: {integrity: sha512-oAFea8dZgCtVVVTEC7fv3T5CbZW9BxpFzGGxC79xakTr6ooeEqmRuvQydIiDAkglZEAd09LgVf1RoDnL54fu5w==}
+  '@vue/compiler-core@3.5.39':
+    resolution: {integrity: sha512-16KBTEXAJCpDr0mwlw+AZyhu8iyC7R3S2vBwsI7QnWJU6X3WKc9VKeNEZpiMdZ569qWhz9574L3vV55qRL0Vtw==}
 
   '@vue/compiler-dom@3.5.31':
     resolution: {integrity: sha512-BMY/ozS/xxjYqRFL+tKdRpATJYDTTgWSo0+AJvJNg4ig+Hgb0dOsHPXvloHQ5hmlivUqw1Yt2pPIqp4e0v1GUw==}
 
+  '@vue/compiler-dom@3.5.39':
+    resolution: {integrity: sha512-oQPigALqYbNxTNPvNgSOe+czwVExfbVF02lz8jP0S3AXJiu3jxYDygNUiqSep4ezzW8XgnubqH63My2A7JR/vg==}
+
   '@vue/compiler-sfc@3.5.31':
     resolution: {integrity: sha512-M8wpPgR9UJ8MiRGjppvx9uWJfLV7A/T+/rL8s/y3QG3u0c2/YZgff3d6SuimKRIhcYnWg5fTfDMlz2E6seUW8Q==}
 
+  '@vue/compiler-sfc@3.5.39':
+    resolution: {integrity: sha512-d0ki86iOyN8LoZPBmk5SJWNwHP19CnDDCfuo//+2WJa2g5Ke0Jay983PIBIcSSzldC68I8DrD5GrHV3OSDfodg==}
+
   '@vue/compiler-ssr@3.5.31':
     resolution: {integrity: sha512-h0xIMxrt/LHOvJKMri+vdYT92BrK3HFLtDqq9Pr/lVVfE4IyKZKvWf0vJFW10Yr6nX02OR4MkJwI0c1HDa1hog==}
+
+  '@vue/compiler-ssr@3.5.39':
+    resolution: {integrity: sha512-Ce7/wvwMHai74bdszfXExdazFigYnlF9zgCmEQUcM1j0fOymlouZ7XilTYNo8oUjhlnjYOZbGrcYKuqjz89Ucw==}
 
   '@vue/devtools-api@6.6.4':
     resolution: {integrity: sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==}
@@ -2902,25 +2914,25 @@ packages:
   '@vue/language-core@3.2.4':
     resolution: {integrity: sha512-bqBGuSG4KZM45KKTXzGtoCl9cWju5jsaBKaJJe3h5hRAAWpZUuj5G+L+eI01sPIkm4H6setKRlw7E85wLdDNew==}
 
-  '@vue/reactivity@3.5.31':
-    resolution: {integrity: sha512-DtKXxk9E/KuVvt8VxWu+6Luc9I9ETNcqR1T1oW1gf02nXaZ1kuAx58oVu7uX9XxJR0iJCro6fqBLw9oSBELo5g==}
+  '@vue/reactivity@3.5.39':
+    resolution: {integrity: sha512-TpsuBJ9gGlZa5d23XcM2y8EXanz9dZeVDQBXRwzy46ItgvM+rWpzs+UVM0wcRLxGvcav0HE5jz2gNL53xlRAog==}
 
-  '@vue/runtime-core@3.5.31':
-    resolution: {integrity: sha512-AZPmIHXEAyhpkmN7aWlqjSfYynmkWlluDNPHMCZKFHH+lLtxP/30UJmoVhXmbDoP1Ng0jG0fyY2zCj1PnSSA6Q==}
+  '@vue/runtime-core@3.5.39':
+    resolution: {integrity: sha512-9GLtNyRvPAUMbX+7ono0RC2j0guo2LXVi8LvcmAooImACUKm0oFf0jjwbX8/H0AE/t1nxhAkn8RSl9PMCzzxZw==}
 
-  '@vue/runtime-dom@3.5.31':
-    resolution: {integrity: sha512-xQJsNRmGPeDCJq/u813tyonNgWBFjzfVkBwDREdEWndBnGdHLHgkwNBQxLtg4zDrzKTEcnikUy1UUNecb3lJ6g==}
+  '@vue/runtime-dom@3.5.39':
+    resolution: {integrity: sha512-7Y6aAGboKcXAZ3ECuUy7RrS5yy2r47dhTp2SKaJmYxjopImaVFaNa5Ne66NwGovsrxVAl5S5rwc7m22UG7Lmww==}
 
-  '@vue/server-renderer@3.5.31':
-    resolution: {integrity: sha512-GJuwRvMcdZX/CriUnyIIOGkx3rMV3H6sOu0JhdKbduaeCji6zb60iOGMY7tFoN24NfsUYoFBhshZtGxGpxO4iA==}
+  '@vue/server-renderer@3.5.39':
+    resolution: {integrity: sha512-yZSakiAGw85rZfG7UM8akMnIF+FmeiNk47uvHf2nVBBSe+dIKUhZuZq9+XgJhbV3nS5Z4ALH23/MpXofW+mbcw==}
     peerDependencies:
-      vue: 3.5.31
-
-  '@vue/shared@3.5.27':
-    resolution: {integrity: sha512-dXr/3CgqXsJkZ0n9F3I4elY8wM9jMJpP3pvRG52r6m0tu/MsAFIe6JpXVGeNMd/D9F4hQynWT8Rfuj0bdm9kFQ==}
+      vue: 3.5.39
 
   '@vue/shared@3.5.31':
     resolution: {integrity: sha512-nBxuiuS9Lj5bPkPbWogPUnjxxWpkRniX7e5UBQDWl6Fsf4roq9wwV+cR7ezQ4zXswNvPIlsdj1slcLB7XCsRAw==}
+
+  '@vue/shared@3.5.39':
+    resolution: {integrity: sha512-l1rrBtBfTnmxvtsvdQDXltUUy8S1Y+ZaqdfUzmAnJkTd8Z8rv5v/ytW+TKiqEOWyHPoqtPlNFSs0lhRmYVSHVA==}
 
   '@vue/test-utils@2.4.6':
     resolution: {integrity: sha512-FMxEjOpYNYiFe0GkaHsnJPXFHxQ6m4t8vI/ElPGpMWxZKpmRvQ33OIrvRXemy6yha03RxhOlQuy+gZMC3CQSow==}
@@ -4958,6 +4970,11 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanoid@3.3.15:
+    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   nanotar@0.3.0:
     resolution: {integrity: sha512-Kv2JYYiCzt16Kt5QwAc9BFG89xfPNBx+oQL4GQXD9nLqPkZBiNaqaCWtwnbk/q7UVsTYevvM1b0UF8zmEI4pCg==}
 
@@ -5408,8 +5425,8 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.5.6:
-    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+  postcss@8.5.16:
+    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
     engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.8:
@@ -6480,8 +6497,8 @@ packages:
     peerDependencies:
       typescript: '>=5.0.0'
 
-  vue@3.5.31:
-    resolution: {integrity: sha512-iV/sU9SzOlmA/0tygSmjkEN6Jbs3nPoIPFhCMLD2STrjgOU8DX7ZtzMhg4ahVwf5Rp9KoFzcXeB1ZrVbLBp5/Q==}
+  vue@3.5.39:
+    resolution: {integrity: sha512-xmZCYabFGcirU8r0fTuvl/LICc1OU620rnqepaJDL/a141ZigkG7AyaxQLdqJ02ZRYzWe6YPaDHeQx7MfknQfA==}
     peerDependencies:
       typescript: '*'
     peerDependenciesMeta:
@@ -6691,8 +6708,8 @@ snapshots:
 
   '@babel/generator@7.28.6':
     dependencies:
-      '@babel/parser': 7.28.6
-      '@babel/types': 7.28.6
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
@@ -6742,7 +6759,7 @@ snapshots:
   '@babel/helper-module-imports@7.28.6':
     dependencies:
       '@babel/traverse': 7.28.6
-      '@babel/types': 7.28.6
+      '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -6779,7 +6796,11 @@ snapshots:
 
   '@babel/helper-string-parser@7.27.1': {}
 
+  '@babel/helper-string-parser@7.29.7': {}
+
   '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
 
   '@babel/helper-validator-option@7.27.1': {}
 
@@ -6788,17 +6809,13 @@ snapshots:
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
 
-  '@babel/parser@7.28.6':
-    dependencies:
-      '@babel/types': 7.28.6
-
-  '@babel/parser@7.29.0':
-    dependencies:
-      '@babel/types': 7.29.0
-
   '@babel/parser@7.29.2':
     dependencies:
       '@babel/types': 7.29.0
+
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
 
   '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0)':
     dependencies:
@@ -6826,7 +6843,7 @@ snapshots:
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
-      '@babel/parser': 7.29.0
+      '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
 
   '@babel/traverse@7.28.6':
@@ -6834,9 +6851,9 @@ snapshots:
       '@babel/code-frame': 7.28.6
       '@babel/generator': 7.28.6
       '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.28.6
+      '@babel/parser': 7.29.2
       '@babel/template': 7.28.6
-      '@babel/types': 7.28.6
+      '@babel/types': 7.29.0
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
@@ -6853,15 +6870,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/types@7.28.6':
-    dependencies:
-      '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
-
   '@babel/types@7.29.0':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
 
   '@bomb.sh/tab@0.0.14(cac@6.7.14)(citty@0.2.2)':
     optionalDependencies:
@@ -7312,11 +7329,11 @@ snapshots:
 
   '@floating-ui/utils@0.2.10': {}
 
-  '@floating-ui/vue@1.1.9(vue@3.5.31(typescript@5.9.3))':
+  '@floating-ui/vue@1.1.9(vue@3.5.39(typescript@5.9.3))':
     dependencies:
       '@floating-ui/dom': 1.7.4
       '@floating-ui/utils': 0.2.10
-      vue-demi: 0.14.10(vue@3.5.31(typescript@5.9.3))
+      vue-demi: 0.14.10(vue@3.5.39(typescript@5.9.3))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
@@ -7352,10 +7369,10 @@ snapshots:
       '@iconify/types': 2.0.0
       mlly: 1.8.0
 
-  '@iconify/vue@5.0.0(vue@3.5.31(typescript@5.9.3))':
+  '@iconify/vue@5.0.0(vue@3.5.39(typescript@5.9.3))':
     dependencies:
       '@iconify/types': 2.0.0
-      vue: 3.5.31(typescript@5.9.3)
+      vue: 3.5.39(typescript@5.9.3)
 
   '@internationalized/date@3.11.0':
     dependencies:
@@ -7547,12 +7564,12 @@ snapshots:
       pkg-types: 2.3.0
       semver: 7.7.4
 
-  '@nuxt/devtools@3.2.4(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))(vue@3.5.31(typescript@5.9.3))':
+  '@nuxt/devtools@3.2.4(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))(vue@3.5.39(typescript@5.9.3))':
     dependencies:
       '@nuxt/devtools-kit': 3.2.4(magicast@0.5.2)(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))
       '@nuxt/devtools-wizard': 3.2.4
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
-      '@vue/devtools-core': 8.1.1(vue@3.5.31(typescript@5.9.3))
+      '@vue/devtools-core': 8.1.1(vue@3.5.39(typescript@5.9.3))
       '@vue/devtools-kit': 8.1.1
       birpc: 4.0.0
       consola: 3.4.2
@@ -7579,7 +7596,7 @@ snapshots:
       tinyglobby: 0.2.15
       vite: 7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3)
       vite-plugin-inspect: 11.3.3(@nuxt/kit@4.4.2(magicast@0.5.2))(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))
-      vite-plugin-vue-tracer: 1.3.0(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))(vue@3.5.31(typescript@5.9.3))
+      vite-plugin-vue-tracer: 1.3.0(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))(vue@3.5.39(typescript@5.9.3))
       which: 6.0.1
       ws: 8.20.0
     transitivePeerDependencies:
@@ -7588,7 +7605,7 @@ snapshots:
       - utf-8-validate
       - vue
 
-  '@nuxt/eslint-config@1.15.1(@typescript-eslint/utils@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.31)(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+  '@nuxt/eslint-config@1.15.1(@typescript-eslint/utils@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.39)(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@antfu/install-pkg': 1.1.0
       '@clack/prompts': 1.0.1
@@ -7607,7 +7624,7 @@ snapshots:
       eslint-plugin-regexp: 3.0.0(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-unicorn: 62.0.0(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-vue: 10.7.0(@stylistic/eslint-plugin@5.9.0(eslint@9.39.2(jiti@2.6.1)))(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(vue-eslint-parser@10.2.0(eslint@9.39.2(jiti@2.6.1)))
-      eslint-processor-vue-blocks: 2.0.0(@vue/compiler-sfc@3.5.31)(eslint@9.39.2(jiti@2.6.1))
+      eslint-processor-vue-blocks: 2.0.0(@vue/compiler-sfc@3.5.39)(eslint@9.39.2(jiti@2.6.1))
       globals: 17.3.0
       local-pkg: 1.1.2
       pathe: 2.0.3
@@ -7628,11 +7645,11 @@ snapshots:
       - supports-color
       - typescript
 
-  '@nuxt/eslint@1.15.1(@typescript-eslint/utils@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.31)(eslint@9.39.2(jiti@2.6.1))(magicast@0.5.2)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))':
+  '@nuxt/eslint@1.15.1(@typescript-eslint/utils@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.39)(eslint@9.39.2(jiti@2.6.1))(magicast@0.5.2)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))':
     dependencies:
       '@eslint/config-inspector': 1.4.2(eslint@9.39.2(jiti@2.6.1))
       '@nuxt/devtools-kit': 3.1.1(magicast@0.5.2)(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))
-      '@nuxt/eslint-config': 1.15.1(@typescript-eslint/utils@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.31)(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@nuxt/eslint-config': 1.15.1(@typescript-eslint/utils@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.39)(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       '@nuxt/eslint-plugin': 1.15.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       '@nuxt/kit': 4.3.1(magicast@0.5.2)
       chokidar: 5.0.0
@@ -7702,12 +7719,12 @@ snapshots:
       - uploadthing
       - vite
 
-  '@nuxt/icon@2.2.1(magicast@0.5.2)(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))(vue@3.5.31(typescript@5.9.3))':
+  '@nuxt/icon@2.2.1(magicast@0.5.2)(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))(vue@3.5.39(typescript@5.9.3))':
     dependencies:
       '@iconify/collections': 1.0.642
       '@iconify/types': 2.0.0
       '@iconify/utils': 3.1.0
-      '@iconify/vue': 5.0.0(vue@3.5.31(typescript@5.9.3))
+      '@iconify/vue': 5.0.0(vue@3.5.39(typescript@5.9.3))
       '@nuxt/devtools-kit': 3.1.1(magicast@0.5.2)(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))
       '@nuxt/kit': 4.3.0(magicast@0.5.2)
       consola: 3.4.2
@@ -7824,12 +7841,12 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/nitro-server@4.4.2(@babel/core@7.29.0)(db0@0.3.4)(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@parcel/watcher@2.5.6)(@types/node@25.2.2)(@vue/compiler-sfc@3.5.31)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.60.1))(rollup@4.60.1)(srvx@0.11.14)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))(vue-tsc@3.2.4(typescript@5.9.3))(yaml@2.8.3))(srvx@0.11.14)(typescript@5.9.3)':
+  '@nuxt/nitro-server@4.4.2(@babel/core@7.29.0)(db0@0.3.4)(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@parcel/watcher@2.5.6)(@types/node@25.2.2)(@vue/compiler-sfc@3.5.39)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.60.1))(rollup@4.60.1)(srvx@0.11.14)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))(vue-tsc@3.2.4(typescript@5.9.3))(yaml@2.8.3))(srvx@0.11.14)(typescript@5.9.3)':
     dependencies:
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
       '@nuxt/devalue': 2.0.2
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
-      '@unhead/vue': 2.1.12(vue@3.5.31(typescript@5.9.3))
+      '@unhead/vue': 2.1.12(vue@3.5.39(typescript@5.9.3))
       '@vue/shared': 3.5.31
       consola: 3.4.2
       defu: 6.1.6
@@ -7843,7 +7860,7 @@ snapshots:
       klona: 2.0.6
       mocked-exports: 0.1.1
       nitropack: 2.13.3(srvx@0.11.14)
-      nuxt: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@parcel/watcher@2.5.6)(@types/node@25.2.2)(@vue/compiler-sfc@3.5.31)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.60.1))(rollup@4.60.1)(srvx@0.11.14)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))(vue-tsc@3.2.4(typescript@5.9.3))(yaml@2.8.3)
+      nuxt: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@parcel/watcher@2.5.6)(@types/node@25.2.2)(@vue/compiler-sfc@3.5.39)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.60.1))(rollup@4.60.1)(srvx@0.11.14)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))(vue-tsc@3.2.4(typescript@5.9.3))(yaml@2.8.3)
       nypm: 0.6.5
       ohash: 2.0.11
       pathe: 2.0.3
@@ -7853,7 +7870,7 @@ snapshots:
       ufo: 1.6.3
       unctx: 2.5.0
       unstorage: 1.17.5(db0@0.3.4)(ioredis@5.10.1)
-      vue: 3.5.31(typescript@5.9.3)
+      vue: 3.5.39(typescript@5.9.3)
       vue-bundle-renderer: 2.2.0
       vue-devtools-stub: 0.1.0
     transitivePeerDependencies:
@@ -7895,7 +7912,7 @@ snapshots:
 
   '@nuxt/schema@4.3.0':
     dependencies:
-      '@vue/shared': 3.5.27
+      '@vue/shared': 3.5.31
       defu: 6.1.4
       pathe: 2.0.3
       pkg-types: 2.3.0
@@ -7918,28 +7935,28 @@ snapshots:
       rc9: 3.0.1
       std-env: 4.0.0
 
-  '@nuxt/ui@4.4.0(@tiptap/extensions@3.16.0(@tiptap/core@3.16.0(@tiptap/pm@3.16.0))(@tiptap/pm@3.16.0))(@tiptap/y-tiptap@3.0.1(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.5)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(change-case@5.4.4)(db0@0.3.4)(embla-carousel@8.6.0)(ioredis@5.10.1)(magicast@0.5.2)(tailwindcss@4.2.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))(vue-router@4.6.4(vue@3.5.31(typescript@5.9.3)))(vue@3.5.31(typescript@5.9.3))(yjs@13.6.29)(zod@4.3.6)':
+  '@nuxt/ui@4.4.0(@tiptap/extensions@3.16.0(@tiptap/core@3.16.0(@tiptap/pm@3.16.0))(@tiptap/pm@3.16.0))(@tiptap/y-tiptap@3.0.1(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.5)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(change-case@5.4.4)(db0@0.3.4)(embla-carousel@8.6.0)(ioredis@5.10.1)(magicast@0.5.2)(tailwindcss@4.2.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))(vue-router@4.6.4(vue@3.5.39(typescript@5.9.3)))(vue@3.5.39(typescript@5.9.3))(yjs@13.6.29)(zod@4.3.6)':
     dependencies:
       '@floating-ui/dom': 1.7.4
-      '@iconify/vue': 5.0.0(vue@3.5.31(typescript@5.9.3))
+      '@iconify/vue': 5.0.0(vue@3.5.39(typescript@5.9.3))
       '@internationalized/date': 3.11.0
       '@internationalized/number': 3.6.5
       '@nuxt/fonts': 0.12.1(db0@0.3.4)(ioredis@5.10.1)(magicast@0.5.2)(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))
-      '@nuxt/icon': 2.2.1(magicast@0.5.2)(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))(vue@3.5.31(typescript@5.9.3))
+      '@nuxt/icon': 2.2.1(magicast@0.5.2)(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))(vue@3.5.39(typescript@5.9.3))
       '@nuxt/kit': 4.3.0(magicast@0.5.2)
       '@nuxt/schema': 4.3.0
       '@nuxtjs/color-mode': 3.5.2(magicast@0.5.2)
       '@standard-schema/spec': 1.1.0
       '@tailwindcss/postcss': 4.1.18
       '@tailwindcss/vite': 4.1.18(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))
-      '@tanstack/vue-table': 8.21.3(vue@3.5.31(typescript@5.9.3))
-      '@tanstack/vue-virtual': 3.13.18(vue@3.5.31(typescript@5.9.3))
+      '@tanstack/vue-table': 8.21.3(vue@3.5.39(typescript@5.9.3))
+      '@tanstack/vue-virtual': 3.13.18(vue@3.5.39(typescript@5.9.3))
       '@tiptap/core': 3.16.0(@tiptap/pm@3.16.0)
       '@tiptap/extension-bubble-menu': 3.16.0(@tiptap/core@3.16.0(@tiptap/pm@3.16.0))(@tiptap/pm@3.16.0)
       '@tiptap/extension-code': 3.16.0(@tiptap/core@3.16.0(@tiptap/pm@3.16.0))
       '@tiptap/extension-collaboration': 3.16.0(@tiptap/core@3.16.0(@tiptap/pm@3.16.0))(@tiptap/pm@3.16.0)(@tiptap/y-tiptap@3.0.1(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.5)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(yjs@13.6.29)
       '@tiptap/extension-drag-handle': 3.16.0(@tiptap/core@3.16.0(@tiptap/pm@3.16.0))(@tiptap/extension-collaboration@3.16.0(@tiptap/core@3.16.0(@tiptap/pm@3.16.0))(@tiptap/pm@3.16.0)(@tiptap/y-tiptap@3.0.1(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.5)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(yjs@13.6.29))(@tiptap/extension-node-range@3.16.0(@tiptap/core@3.16.0(@tiptap/pm@3.16.0))(@tiptap/pm@3.16.0))(@tiptap/pm@3.16.0)(@tiptap/y-tiptap@3.0.1(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.5)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))
-      '@tiptap/extension-drag-handle-vue-3': 3.16.0(@tiptap/extension-drag-handle@3.16.0(@tiptap/core@3.16.0(@tiptap/pm@3.16.0))(@tiptap/extension-collaboration@3.16.0(@tiptap/core@3.16.0(@tiptap/pm@3.16.0))(@tiptap/pm@3.16.0)(@tiptap/y-tiptap@3.0.1(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.5)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(yjs@13.6.29))(@tiptap/extension-node-range@3.16.0(@tiptap/core@3.16.0(@tiptap/pm@3.16.0))(@tiptap/pm@3.16.0))(@tiptap/pm@3.16.0)(@tiptap/y-tiptap@3.0.1(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.5)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29)))(@tiptap/pm@3.16.0)(@tiptap/vue-3@3.16.0(@floating-ui/dom@1.7.4)(@tiptap/core@3.16.0(@tiptap/pm@3.16.0))(@tiptap/pm@3.16.0)(vue@3.5.31(typescript@5.9.3)))(vue@3.5.31(typescript@5.9.3))
+      '@tiptap/extension-drag-handle-vue-3': 3.16.0(@tiptap/extension-drag-handle@3.16.0(@tiptap/core@3.16.0(@tiptap/pm@3.16.0))(@tiptap/extension-collaboration@3.16.0(@tiptap/core@3.16.0(@tiptap/pm@3.16.0))(@tiptap/pm@3.16.0)(@tiptap/y-tiptap@3.0.1(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.5)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(yjs@13.6.29))(@tiptap/extension-node-range@3.16.0(@tiptap/core@3.16.0(@tiptap/pm@3.16.0))(@tiptap/pm@3.16.0))(@tiptap/pm@3.16.0)(@tiptap/y-tiptap@3.0.1(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.5)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29)))(@tiptap/pm@3.16.0)(@tiptap/vue-3@3.16.0(@floating-ui/dom@1.7.4)(@tiptap/core@3.16.0(@tiptap/pm@3.16.0))(@tiptap/pm@3.16.0)(vue@3.5.39(typescript@5.9.3)))(vue@3.5.39(typescript@5.9.3))
       '@tiptap/extension-floating-menu': 3.16.0(@floating-ui/dom@1.7.4)(@tiptap/core@3.16.0(@tiptap/pm@3.16.0))(@tiptap/pm@3.16.0)
       '@tiptap/extension-horizontal-rule': 3.16.0(@tiptap/core@3.16.0(@tiptap/pm@3.16.0))(@tiptap/pm@3.16.0)
       '@tiptap/extension-image': 3.16.0(@tiptap/core@3.16.0(@tiptap/pm@3.16.0))
@@ -7950,11 +7967,11 @@ snapshots:
       '@tiptap/pm': 3.16.0
       '@tiptap/starter-kit': 3.16.0
       '@tiptap/suggestion': 3.16.0(@tiptap/core@3.16.0(@tiptap/pm@3.16.0))(@tiptap/pm@3.16.0)
-      '@tiptap/vue-3': 3.16.0(@floating-ui/dom@1.7.4)(@tiptap/core@3.16.0(@tiptap/pm@3.16.0))(@tiptap/pm@3.16.0)(vue@3.5.31(typescript@5.9.3))
-      '@unhead/vue': 2.1.2(vue@3.5.31(typescript@5.9.3))
-      '@vueuse/core': 14.2.1(vue@3.5.31(typescript@5.9.3))
-      '@vueuse/integrations': 14.1.0(change-case@5.4.4)(fuse.js@7.1.0)(vue@3.5.31(typescript@5.9.3))
-      '@vueuse/shared': 14.1.0(vue@3.5.31(typescript@5.9.3))
+      '@tiptap/vue-3': 3.16.0(@floating-ui/dom@1.7.4)(@tiptap/core@3.16.0(@tiptap/pm@3.16.0))(@tiptap/pm@3.16.0)(vue@3.5.39(typescript@5.9.3))
+      '@unhead/vue': 2.1.2(vue@3.5.39(typescript@5.9.3))
+      '@vueuse/core': 14.2.1(vue@3.5.39(typescript@5.9.3))
+      '@vueuse/integrations': 14.1.0(change-case@5.4.4)(fuse.js@7.1.0)(vue@3.5.39(typescript@5.9.3))
+      '@vueuse/shared': 14.1.0(vue@3.5.39(typescript@5.9.3))
       colortranslator: 5.0.0
       consola: 3.4.2
       defu: 6.1.4
@@ -7963,17 +7980,17 @@ snapshots:
       embla-carousel-autoplay: 8.6.0(embla-carousel@8.6.0)
       embla-carousel-class-names: 8.6.0(embla-carousel@8.6.0)
       embla-carousel-fade: 8.6.0(embla-carousel@8.6.0)
-      embla-carousel-vue: 8.6.0(vue@3.5.31(typescript@5.9.3))
+      embla-carousel-vue: 8.6.0(vue@3.5.39(typescript@5.9.3))
       embla-carousel-wheel-gestures: 8.1.0(embla-carousel@8.6.0)
       fuse.js: 7.1.0
       hookable: 5.5.3
       knitwork: 1.3.0
       magic-string: 0.30.21
       mlly: 1.8.0
-      motion-v: 1.10.3(@vueuse/core@14.2.1(vue@3.5.31(typescript@5.9.3)))(vue@3.5.31(typescript@5.9.3))
+      motion-v: 1.10.3(@vueuse/core@14.2.1(vue@3.5.39(typescript@5.9.3)))(vue@3.5.39(typescript@5.9.3))
       ohash: 2.0.11
       pathe: 2.0.3
-      reka-ui: 2.7.0(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3))
+      reka-ui: 2.7.0(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3))
       scule: 1.3.0
       tailwind-merge: 3.4.0
       tailwind-variants: 3.2.2(tailwind-merge@3.4.0)(tailwindcss@4.2.0)
@@ -7982,12 +7999,12 @@ snapshots:
       typescript: 5.9.3
       ufo: 1.6.3
       unplugin: 2.3.11
-      unplugin-auto-import: 21.0.0(@nuxt/kit@4.3.0(magicast@0.5.2))(@vueuse/core@14.2.1(vue@3.5.31(typescript@5.9.3)))
-      unplugin-vue-components: 31.0.0(@nuxt/kit@4.3.0(magicast@0.5.2))(vue@3.5.31(typescript@5.9.3))
-      vaul-vue: 0.4.1(reka-ui@2.7.0(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3)))(vue@3.5.31(typescript@5.9.3))
+      unplugin-auto-import: 21.0.0(@nuxt/kit@4.3.0(magicast@0.5.2))(@vueuse/core@14.2.1(vue@3.5.39(typescript@5.9.3)))
+      unplugin-vue-components: 31.0.0(@nuxt/kit@4.3.0(magicast@0.5.2))(vue@3.5.39(typescript@5.9.3))
+      vaul-vue: 0.4.1(reka-ui@2.7.0(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))(vue@3.5.39(typescript@5.9.3))
       vue-component-type-helpers: 3.2.2
     optionalDependencies:
-      vue-router: 4.6.4(vue@3.5.31(typescript@5.9.3))
+      vue-router: 4.6.4(vue@3.5.39(typescript@5.9.3))
       zod: 4.3.6
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -8031,12 +8048,12 @@ snapshots:
       - vue
       - yjs
 
-  '@nuxt/vite-builder@4.4.2(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.2.2)(eslint@9.39.2(jiti@2.6.1))(lightningcss@1.31.1)(magicast@0.5.2)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@parcel/watcher@2.5.6)(@types/node@25.2.2)(@vue/compiler-sfc@3.5.31)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.60.1))(rollup@4.60.1)(srvx@0.11.14)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))(vue-tsc@3.2.4(typescript@5.9.3))(yaml@2.8.3))(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(typescript@5.9.3)(vue-tsc@3.2.4(typescript@5.9.3))(vue@3.5.31(typescript@5.9.3))(yaml@2.8.3)':
+  '@nuxt/vite-builder@4.4.2(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.2.2)(eslint@9.39.2(jiti@2.6.1))(lightningcss@1.31.1)(magicast@0.5.2)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@parcel/watcher@2.5.6)(@types/node@25.2.2)(@vue/compiler-sfc@3.5.39)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.60.1))(rollup@4.60.1)(srvx@0.11.14)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))(vue-tsc@3.2.4(typescript@5.9.3))(yaml@2.8.3))(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(typescript@5.9.3)(vue-tsc@3.2.4(typescript@5.9.3))(vue@3.5.39(typescript@5.9.3))(yaml@2.8.3)':
     dependencies:
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
       '@rollup/plugin-replace': 6.0.3(rollup@4.60.1)
-      '@vitejs/plugin-vue': 6.0.5(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))(vue@3.5.31(typescript@5.9.3))
-      '@vitejs/plugin-vue-jsx': 5.1.5(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))(vue@3.5.31(typescript@5.9.3))
+      '@vitejs/plugin-vue': 6.0.5(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))(vue@3.5.39(typescript@5.9.3))
+      '@vitejs/plugin-vue-jsx': 5.1.5(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))(vue@3.5.39(typescript@5.9.3))
       autoprefixer: 10.4.27(postcss@8.5.8)
       consola: 3.4.2
       cssnano: 7.1.4(postcss@8.5.8)
@@ -8049,7 +8066,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@parcel/watcher@2.5.6)(@types/node@25.2.2)(@vue/compiler-sfc@3.5.31)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.60.1))(rollup@4.60.1)(srvx@0.11.14)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))(vue-tsc@3.2.4(typescript@5.9.3))(yaml@2.8.3)
+      nuxt: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@parcel/watcher@2.5.6)(@types/node@25.2.2)(@vue/compiler-sfc@3.5.39)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.60.1))(rollup@4.60.1)(srvx@0.11.14)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))(vue-tsc@3.2.4(typescript@5.9.3))(yaml@2.8.3)
       nypm: 0.6.5
       pathe: 2.0.3
       pkg-types: 2.3.0
@@ -8061,7 +8078,7 @@ snapshots:
       vite: 7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3)
       vite-node: 5.3.0(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3)
       vite-plugin-checker: 0.12.0(eslint@9.39.2(jiti@2.6.1))(optionator@0.9.4)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))(vue-tsc@3.2.4(typescript@5.9.3))
-      vue: 3.5.31(typescript@5.9.3)
+      vue: 3.5.39(typescript@5.9.3)
       vue-bundle-renderer: 2.2.0
     optionalDependencies:
       '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
@@ -8728,7 +8745,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.1.18
       '@tailwindcss/oxide': 4.1.18
-      postcss: 8.5.6
+      postcss: 8.5.8
       tailwindcss: 4.1.18
 
   '@tailwindcss/vite@4.1.18(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))':
@@ -8742,15 +8759,15 @@ snapshots:
 
   '@tanstack/virtual-core@3.13.18': {}
 
-  '@tanstack/vue-table@8.21.3(vue@3.5.31(typescript@5.9.3))':
+  '@tanstack/vue-table@8.21.3(vue@3.5.39(typescript@5.9.3))':
     dependencies:
       '@tanstack/table-core': 8.21.3
-      vue: 3.5.31(typescript@5.9.3)
+      vue: 3.5.39(typescript@5.9.3)
 
-  '@tanstack/vue-virtual@3.13.18(vue@3.5.31(typescript@5.9.3))':
+  '@tanstack/vue-virtual@3.13.18(vue@3.5.39(typescript@5.9.3))':
     dependencies:
       '@tanstack/virtual-core': 3.13.18
-      vue: 3.5.31(typescript@5.9.3)
+      vue: 3.5.39(typescript@5.9.3)
 
   '@tiptap/core@3.16.0(@tiptap/pm@3.16.0)':
     dependencies:
@@ -8794,12 +8811,12 @@ snapshots:
     dependencies:
       '@tiptap/core': 3.16.0(@tiptap/pm@3.16.0)
 
-  '@tiptap/extension-drag-handle-vue-3@3.16.0(@tiptap/extension-drag-handle@3.16.0(@tiptap/core@3.16.0(@tiptap/pm@3.16.0))(@tiptap/extension-collaboration@3.16.0(@tiptap/core@3.16.0(@tiptap/pm@3.16.0))(@tiptap/pm@3.16.0)(@tiptap/y-tiptap@3.0.1(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.5)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(yjs@13.6.29))(@tiptap/extension-node-range@3.16.0(@tiptap/core@3.16.0(@tiptap/pm@3.16.0))(@tiptap/pm@3.16.0))(@tiptap/pm@3.16.0)(@tiptap/y-tiptap@3.0.1(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.5)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29)))(@tiptap/pm@3.16.0)(@tiptap/vue-3@3.16.0(@floating-ui/dom@1.7.4)(@tiptap/core@3.16.0(@tiptap/pm@3.16.0))(@tiptap/pm@3.16.0)(vue@3.5.31(typescript@5.9.3)))(vue@3.5.31(typescript@5.9.3))':
+  '@tiptap/extension-drag-handle-vue-3@3.16.0(@tiptap/extension-drag-handle@3.16.0(@tiptap/core@3.16.0(@tiptap/pm@3.16.0))(@tiptap/extension-collaboration@3.16.0(@tiptap/core@3.16.0(@tiptap/pm@3.16.0))(@tiptap/pm@3.16.0)(@tiptap/y-tiptap@3.0.1(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.5)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(yjs@13.6.29))(@tiptap/extension-node-range@3.16.0(@tiptap/core@3.16.0(@tiptap/pm@3.16.0))(@tiptap/pm@3.16.0))(@tiptap/pm@3.16.0)(@tiptap/y-tiptap@3.0.1(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.5)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29)))(@tiptap/pm@3.16.0)(@tiptap/vue-3@3.16.0(@floating-ui/dom@1.7.4)(@tiptap/core@3.16.0(@tiptap/pm@3.16.0))(@tiptap/pm@3.16.0)(vue@3.5.39(typescript@5.9.3)))(vue@3.5.39(typescript@5.9.3))':
     dependencies:
       '@tiptap/extension-drag-handle': 3.16.0(@tiptap/core@3.16.0(@tiptap/pm@3.16.0))(@tiptap/extension-collaboration@3.16.0(@tiptap/core@3.16.0(@tiptap/pm@3.16.0))(@tiptap/pm@3.16.0)(@tiptap/y-tiptap@3.0.1(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.5)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(yjs@13.6.29))(@tiptap/extension-node-range@3.16.0(@tiptap/core@3.16.0(@tiptap/pm@3.16.0))(@tiptap/pm@3.16.0))(@tiptap/pm@3.16.0)(@tiptap/y-tiptap@3.0.1(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.5)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))
       '@tiptap/pm': 3.16.0
-      '@tiptap/vue-3': 3.16.0(@floating-ui/dom@1.7.4)(@tiptap/core@3.16.0(@tiptap/pm@3.16.0))(@tiptap/pm@3.16.0)(vue@3.5.31(typescript@5.9.3))
-      vue: 3.5.31(typescript@5.9.3)
+      '@tiptap/vue-3': 3.16.0(@floating-ui/dom@1.7.4)(@tiptap/core@3.16.0(@tiptap/pm@3.16.0))(@tiptap/pm@3.16.0)(vue@3.5.39(typescript@5.9.3))
+      vue: 3.5.39(typescript@5.9.3)
 
   '@tiptap/extension-drag-handle@3.16.0(@tiptap/core@3.16.0(@tiptap/pm@3.16.0))(@tiptap/extension-collaboration@3.16.0(@tiptap/core@3.16.0(@tiptap/pm@3.16.0))(@tiptap/pm@3.16.0)(@tiptap/y-tiptap@3.0.1(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.5)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(yjs@13.6.29))(@tiptap/extension-node-range@3.16.0(@tiptap/core@3.16.0(@tiptap/pm@3.16.0))(@tiptap/pm@3.16.0))(@tiptap/pm@3.16.0)(@tiptap/y-tiptap@3.0.1(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.5)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))':
     dependencies:
@@ -8963,12 +8980,12 @@ snapshots:
       '@tiptap/core': 3.16.0(@tiptap/pm@3.16.0)
       '@tiptap/pm': 3.16.0
 
-  '@tiptap/vue-3@3.16.0(@floating-ui/dom@1.7.4)(@tiptap/core@3.16.0(@tiptap/pm@3.16.0))(@tiptap/pm@3.16.0)(vue@3.5.31(typescript@5.9.3))':
+  '@tiptap/vue-3@3.16.0(@floating-ui/dom@1.7.4)(@tiptap/core@3.16.0(@tiptap/pm@3.16.0))(@tiptap/pm@3.16.0)(vue@3.5.39(typescript@5.9.3))':
     dependencies:
       '@floating-ui/dom': 1.7.4
       '@tiptap/core': 3.16.0(@tiptap/pm@3.16.0)
       '@tiptap/pm': 3.16.0
-      vue: 3.5.31(typescript@5.9.3)
+      vue: 3.5.39(typescript@5.9.3)
     optionalDependencies:
       '@tiptap/extension-bubble-menu': 3.16.0(@tiptap/core@3.16.0(@tiptap/pm@3.16.0))(@tiptap/pm@3.16.0)
       '@tiptap/extension-floating-menu': 3.16.0(@floating-ui/dom@1.7.4)(@tiptap/core@3.16.0(@tiptap/pm@3.16.0))(@tiptap/pm@3.16.0)
@@ -9311,17 +9328,17 @@ snapshots:
       '@typescript-eslint/types': 8.56.0
       eslint-visitor-keys: 5.0.0
 
-  '@unhead/vue@2.1.12(vue@3.5.31(typescript@5.9.3))':
+  '@unhead/vue@2.1.12(vue@3.5.39(typescript@5.9.3))':
     dependencies:
       hookable: 6.1.0
       unhead: 2.1.12
-      vue: 3.5.31(typescript@5.9.3)
+      vue: 3.5.39(typescript@5.9.3)
 
-  '@unhead/vue@2.1.2(vue@3.5.31(typescript@5.9.3))':
+  '@unhead/vue@2.1.2(vue@3.5.39(typescript@5.9.3))':
     dependencies:
       hookable: 6.0.1
       unhead: 2.1.2
-      vue: 3.5.31(typescript@5.9.3)
+      vue: 3.5.39(typescript@5.9.3)
 
   '@unovis/dagre-layout@0.8.8-2':
     dependencies:
@@ -9405,10 +9422,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@unovis/vue@1.6.4(@unovis/ts@1.6.4)(vue@3.5.31(typescript@5.9.3))':
+  '@unovis/vue@1.6.4(@unovis/ts@1.6.4)(vue@3.5.39(typescript@5.9.3))':
     dependencies:
       '@unovis/ts': 1.6.4
-      vue: 3.5.31(typescript@5.9.3)
+      vue: 3.5.39(typescript@5.9.3)
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     optional: true
@@ -9488,7 +9505,7 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vitejs/plugin-vue-jsx@5.1.5(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))(vue@3.5.31(typescript@5.9.3))':
+  '@vitejs/plugin-vue-jsx@5.1.5(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))(vue@3.5.39(typescript@5.9.3))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
@@ -9496,15 +9513,15 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.13
       '@vue/babel-plugin-jsx': 2.0.1(@babel/core@7.29.0)
       vite: 7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3)
-      vue: 3.5.31(typescript@5.9.3)
+      vue: 3.5.39(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@6.0.5(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))(vue@3.5.31(typescript@5.9.3))':
+  '@vitejs/plugin-vue@6.0.5(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))(vue@3.5.39(typescript@5.9.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.2
       vite: 7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3)
-      vue: 3.5.31(typescript@5.9.3)
+      vue: 3.5.39(typescript@5.9.3)
 
   '@vitest/expect@4.1.2':
     dependencies:
@@ -9559,7 +9576,7 @@ snapshots:
       path-browserify: 1.0.1
       vscode-uri: 3.1.0
 
-  '@vue-macros/common@3.1.2(vue@3.5.31(typescript@5.9.3))':
+  '@vue-macros/common@3.1.2(vue@3.5.39(typescript@5.9.3))':
     dependencies:
       '@vue/compiler-sfc': 3.5.31
       ast-kit: 2.2.0
@@ -9567,7 +9584,7 @@ snapshots:
       magic-string-ast: 1.0.3
       unplugin-utils: 0.3.1
     optionalDependencies:
-      vue: 3.5.31(typescript@5.9.3)
+      vue: 3.5.39(typescript@5.9.3)
 
   '@vue/babel-helper-vue-transform-on@2.0.1': {}
 
@@ -9598,14 +9615,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vue/compiler-core@3.5.27':
-    dependencies:
-      '@babel/parser': 7.28.6
-      '@vue/shared': 3.5.27
-      entities: 7.0.1
-      estree-walker: 2.0.2
-      source-map-js: 1.2.1
-
   '@vue/compiler-core@3.5.31':
     dependencies:
       '@babel/parser': 7.29.2
@@ -9614,15 +9623,23 @@ snapshots:
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
-  '@vue/compiler-dom@3.5.27':
+  '@vue/compiler-core@3.5.39':
     dependencies:
-      '@vue/compiler-core': 3.5.27
-      '@vue/shared': 3.5.27
+      '@babel/parser': 7.29.7
+      '@vue/shared': 3.5.39
+      entities: 7.0.1
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
 
   '@vue/compiler-dom@3.5.31':
     dependencies:
       '@vue/compiler-core': 3.5.31
       '@vue/shared': 3.5.31
+
+  '@vue/compiler-dom@3.5.39':
+    dependencies:
+      '@vue/compiler-core': 3.5.39
+      '@vue/shared': 3.5.39
 
   '@vue/compiler-sfc@3.5.31':
     dependencies:
@@ -9636,10 +9653,27 @@ snapshots:
       postcss: 8.5.8
       source-map-js: 1.2.1
 
+  '@vue/compiler-sfc@3.5.39':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@vue/compiler-core': 3.5.39
+      '@vue/compiler-dom': 3.5.39
+      '@vue/compiler-ssr': 3.5.39
+      '@vue/shared': 3.5.39
+      estree-walker: 2.0.2
+      magic-string: 0.30.21
+      postcss: 8.5.16
+      source-map-js: 1.2.1
+
   '@vue/compiler-ssr@3.5.31':
     dependencies:
       '@vue/compiler-dom': 3.5.31
       '@vue/shared': 3.5.31
+
+  '@vue/compiler-ssr@3.5.39':
+    dependencies:
+      '@vue/compiler-dom': 3.5.39
+      '@vue/shared': 3.5.39
 
   '@vue/devtools-api@6.6.4':
     optional: true
@@ -9648,11 +9682,11 @@ snapshots:
     dependencies:
       '@vue/devtools-kit': 8.1.1
 
-  '@vue/devtools-core@8.1.1(vue@3.5.31(typescript@5.9.3))':
+  '@vue/devtools-core@8.1.1(vue@3.5.39(typescript@5.9.3))':
     dependencies:
       '@vue/devtools-kit': 8.1.1
       '@vue/devtools-shared': 8.1.1
-      vue: 3.5.31(typescript@5.9.3)
+      vue: 3.5.39(typescript@5.9.3)
 
   '@vue/devtools-kit@8.1.1':
     dependencies:
@@ -9666,50 +9700,50 @@ snapshots:
   '@vue/language-core@3.2.4':
     dependencies:
       '@volar/language-core': 2.4.27
-      '@vue/compiler-dom': 3.5.27
-      '@vue/shared': 3.5.27
+      '@vue/compiler-dom': 3.5.31
+      '@vue/shared': 3.5.31
       alien-signals: 3.1.2
       muggle-string: 0.4.1
       path-browserify: 1.0.1
       picomatch: 4.0.3
 
-  '@vue/reactivity@3.5.31':
+  '@vue/reactivity@3.5.39':
     dependencies:
-      '@vue/shared': 3.5.31
+      '@vue/shared': 3.5.39
 
-  '@vue/runtime-core@3.5.31':
+  '@vue/runtime-core@3.5.39':
     dependencies:
-      '@vue/reactivity': 3.5.31
-      '@vue/shared': 3.5.31
+      '@vue/reactivity': 3.5.39
+      '@vue/shared': 3.5.39
 
-  '@vue/runtime-dom@3.5.31':
+  '@vue/runtime-dom@3.5.39':
     dependencies:
-      '@vue/reactivity': 3.5.31
-      '@vue/runtime-core': 3.5.31
-      '@vue/shared': 3.5.31
+      '@vue/reactivity': 3.5.39
+      '@vue/runtime-core': 3.5.39
+      '@vue/shared': 3.5.39
       csstype: 3.2.3
 
-  '@vue/server-renderer@3.5.31(vue@3.5.31(typescript@5.9.3))':
+  '@vue/server-renderer@3.5.39(vue@3.5.39(typescript@5.9.3))':
     dependencies:
-      '@vue/compiler-ssr': 3.5.31
-      '@vue/shared': 3.5.31
-      vue: 3.5.31(typescript@5.9.3)
-
-  '@vue/shared@3.5.27': {}
+      '@vue/compiler-ssr': 3.5.39
+      '@vue/shared': 3.5.39
+      vue: 3.5.39(typescript@5.9.3)
 
   '@vue/shared@3.5.31': {}
+
+  '@vue/shared@3.5.39': {}
 
   '@vue/test-utils@2.4.6':
     dependencies:
       js-beautify: 1.15.4
       vue-component-type-helpers: 2.2.12
 
-  '@vueuse/core@10.11.1(vue@3.5.31(typescript@5.9.3))':
+  '@vueuse/core@10.11.1(vue@3.5.39(typescript@5.9.3))':
     dependencies:
       '@types/web-bluetooth': 0.0.20
       '@vueuse/metadata': 10.11.1
-      '@vueuse/shared': 10.11.1(vue@3.5.31(typescript@5.9.3))
-      vue-demi: 0.14.10(vue@3.5.31(typescript@5.9.3))
+      '@vueuse/shared': 10.11.1(vue@3.5.39(typescript@5.9.3))
+      vue-demi: 0.14.10(vue@3.5.39(typescript@5.9.3))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
@@ -9719,29 +9753,29 @@ snapshots:
       '@types/web-bluetooth': 0.0.21
       '@vueuse/metadata': 12.8.2
       '@vueuse/shared': 12.8.2(typescript@5.9.3)
-      vue: 3.5.31(typescript@5.9.3)
+      vue: 3.5.39(typescript@5.9.3)
     transitivePeerDependencies:
       - typescript
 
-  '@vueuse/core@14.1.0(vue@3.5.31(typescript@5.9.3))':
+  '@vueuse/core@14.1.0(vue@3.5.39(typescript@5.9.3))':
     dependencies:
       '@types/web-bluetooth': 0.0.21
       '@vueuse/metadata': 14.1.0
-      '@vueuse/shared': 14.1.0(vue@3.5.31(typescript@5.9.3))
-      vue: 3.5.31(typescript@5.9.3)
+      '@vueuse/shared': 14.1.0(vue@3.5.39(typescript@5.9.3))
+      vue: 3.5.39(typescript@5.9.3)
 
-  '@vueuse/core@14.2.1(vue@3.5.31(typescript@5.9.3))':
+  '@vueuse/core@14.2.1(vue@3.5.39(typescript@5.9.3))':
     dependencies:
       '@types/web-bluetooth': 0.0.21
       '@vueuse/metadata': 14.2.1
-      '@vueuse/shared': 14.2.1(vue@3.5.31(typescript@5.9.3))
-      vue: 3.5.31(typescript@5.9.3)
+      '@vueuse/shared': 14.2.1(vue@3.5.39(typescript@5.9.3))
+      vue: 3.5.39(typescript@5.9.3)
 
-  '@vueuse/integrations@14.1.0(change-case@5.4.4)(fuse.js@7.1.0)(vue@3.5.31(typescript@5.9.3))':
+  '@vueuse/integrations@14.1.0(change-case@5.4.4)(fuse.js@7.1.0)(vue@3.5.39(typescript@5.9.3))':
     dependencies:
-      '@vueuse/core': 14.1.0(vue@3.5.31(typescript@5.9.3))
-      '@vueuse/shared': 14.1.0(vue@3.5.31(typescript@5.9.3))
-      vue: 3.5.31(typescript@5.9.3)
+      '@vueuse/core': 14.1.0(vue@3.5.39(typescript@5.9.3))
+      '@vueuse/shared': 14.1.0(vue@3.5.39(typescript@5.9.3))
+      vue: 3.5.39(typescript@5.9.3)
     optionalDependencies:
       change-case: 5.4.4
       fuse.js: 7.1.0
@@ -9754,37 +9788,37 @@ snapshots:
 
   '@vueuse/metadata@14.2.1': {}
 
-  '@vueuse/nuxt@14.2.1(magicast@0.5.2)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@parcel/watcher@2.5.6)(@types/node@25.2.2)(@vue/compiler-sfc@3.5.31)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.60.1))(rollup@4.60.1)(srvx@0.11.14)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))(vue-tsc@3.2.4(typescript@5.9.3))(yaml@2.8.3))(vue@3.5.31(typescript@5.9.3))':
+  '@vueuse/nuxt@14.2.1(magicast@0.5.2)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@parcel/watcher@2.5.6)(@types/node@25.2.2)(@vue/compiler-sfc@3.5.39)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.60.1))(rollup@4.60.1)(srvx@0.11.14)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))(vue-tsc@3.2.4(typescript@5.9.3))(yaml@2.8.3))(vue@3.5.39(typescript@5.9.3))':
     dependencies:
       '@nuxt/kit': 4.3.0(magicast@0.5.2)
-      '@vueuse/core': 14.2.1(vue@3.5.31(typescript@5.9.3))
+      '@vueuse/core': 14.2.1(vue@3.5.39(typescript@5.9.3))
       '@vueuse/metadata': 14.2.1
       local-pkg: 1.1.2
-      nuxt: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@parcel/watcher@2.5.6)(@types/node@25.2.2)(@vue/compiler-sfc@3.5.31)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.60.1))(rollup@4.60.1)(srvx@0.11.14)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))(vue-tsc@3.2.4(typescript@5.9.3))(yaml@2.8.3)
-      vue: 3.5.31(typescript@5.9.3)
+      nuxt: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@parcel/watcher@2.5.6)(@types/node@25.2.2)(@vue/compiler-sfc@3.5.39)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.60.1))(rollup@4.60.1)(srvx@0.11.14)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))(vue-tsc@3.2.4(typescript@5.9.3))(yaml@2.8.3)
+      vue: 3.5.39(typescript@5.9.3)
     transitivePeerDependencies:
       - magicast
 
-  '@vueuse/shared@10.11.1(vue@3.5.31(typescript@5.9.3))':
+  '@vueuse/shared@10.11.1(vue@3.5.39(typescript@5.9.3))':
     dependencies:
-      vue-demi: 0.14.10(vue@3.5.31(typescript@5.9.3))
+      vue-demi: 0.14.10(vue@3.5.39(typescript@5.9.3))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
 
   '@vueuse/shared@12.8.2(typescript@5.9.3)':
     dependencies:
-      vue: 3.5.31(typescript@5.9.3)
+      vue: 3.5.39(typescript@5.9.3)
     transitivePeerDependencies:
       - typescript
 
-  '@vueuse/shared@14.1.0(vue@3.5.31(typescript@5.9.3))':
+  '@vueuse/shared@14.1.0(vue@3.5.39(typescript@5.9.3))':
     dependencies:
-      vue: 3.5.31(typescript@5.9.3)
+      vue: 3.5.39(typescript@5.9.3)
 
-  '@vueuse/shared@14.2.1(vue@3.5.31(typescript@5.9.3))':
+  '@vueuse/shared@14.2.1(vue@3.5.39(typescript@5.9.3))':
     dependencies:
-      vue: 3.5.31(typescript@5.9.3)
+      vue: 3.5.39(typescript@5.9.3)
 
   abbrev@2.0.0: {}
 
@@ -10570,11 +10604,11 @@ snapshots:
     dependencies:
       embla-carousel: 8.6.0
 
-  embla-carousel-vue@8.6.0(vue@3.5.31(typescript@5.9.3)):
+  embla-carousel-vue@8.6.0(vue@3.5.39(typescript@5.9.3)):
     dependencies:
       embla-carousel: 8.6.0
       embla-carousel-reactive-utils: 8.6.0(embla-carousel@8.6.0)
-      vue: 3.5.31(typescript@5.9.3)
+      vue: 3.5.39(typescript@5.9.3)
 
   embla-carousel-wheel-gestures@8.1.0(embla-carousel@8.6.0):
     dependencies:
@@ -10816,9 +10850,9 @@ snapshots:
       '@stylistic/eslint-plugin': 5.9.0(eslint@9.39.2(jiti@2.6.1))
       '@typescript-eslint/parser': 8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
 
-  eslint-processor-vue-blocks@2.0.0(@vue/compiler-sfc@3.5.31)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-processor-vue-blocks@2.0.0(@vue/compiler-sfc@3.5.39)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
-      '@vue/compiler-sfc': 3.5.31
+      '@vue/compiler-sfc': 3.5.39
       eslint: 9.39.2(jiti@2.6.1)
 
   eslint-scope@8.4.0:
@@ -11769,13 +11803,13 @@ snapshots:
 
   motion-utils@12.27.2: {}
 
-  motion-v@1.10.3(@vueuse/core@14.2.1(vue@3.5.31(typescript@5.9.3)))(vue@3.5.31(typescript@5.9.3)):
+  motion-v@1.10.3(@vueuse/core@14.2.1(vue@3.5.39(typescript@5.9.3)))(vue@3.5.39(typescript@5.9.3)):
     dependencies:
-      '@vueuse/core': 14.2.1(vue@3.5.31(typescript@5.9.3))
+      '@vueuse/core': 14.2.1(vue@3.5.39(typescript@5.9.3))
       framer-motion: 12.28.1
       hey-listen: 1.0.8
       motion-dom: 12.28.1
-      vue: 3.5.31(typescript@5.9.3)
+      vue: 3.5.39(typescript@5.9.3)
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
       - react
@@ -11792,6 +11826,8 @@ snapshots:
   murmurhash-js@1.0.0: {}
 
   nanoid@3.3.11: {}
+
+  nanoid@3.3.15: {}
 
   nanotar@0.3.0: {}
 
@@ -11943,17 +11979,17 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@parcel/watcher@2.5.6)(@types/node@25.2.2)(@vue/compiler-sfc@3.5.31)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.60.1))(rollup@4.60.1)(srvx@0.11.14)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))(vue-tsc@3.2.4(typescript@5.9.3))(yaml@2.8.3):
+  nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@parcel/watcher@2.5.6)(@types/node@25.2.2)(@vue/compiler-sfc@3.5.39)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.60.1))(rollup@4.60.1)(srvx@0.11.14)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))(vue-tsc@3.2.4(typescript@5.9.3))(yaml@2.8.3):
     dependencies:
       '@dxup/nuxt': 0.4.0(magicast@0.5.2)(typescript@5.9.3)
       '@nuxt/cli': 3.34.0(@nuxt/schema@4.4.2)(cac@6.7.14)(magicast@0.5.2)
-      '@nuxt/devtools': 3.2.4(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))(vue@3.5.31(typescript@5.9.3))
+      '@nuxt/devtools': 3.2.4(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))(vue@3.5.39(typescript@5.9.3))
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
-      '@nuxt/nitro-server': 4.4.2(@babel/core@7.29.0)(db0@0.3.4)(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@parcel/watcher@2.5.6)(@types/node@25.2.2)(@vue/compiler-sfc@3.5.31)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.60.1))(rollup@4.60.1)(srvx@0.11.14)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))(vue-tsc@3.2.4(typescript@5.9.3))(yaml@2.8.3))(srvx@0.11.14)(typescript@5.9.3)
+      '@nuxt/nitro-server': 4.4.2(@babel/core@7.29.0)(db0@0.3.4)(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@parcel/watcher@2.5.6)(@types/node@25.2.2)(@vue/compiler-sfc@3.5.39)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.60.1))(rollup@4.60.1)(srvx@0.11.14)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))(vue-tsc@3.2.4(typescript@5.9.3))(yaml@2.8.3))(srvx@0.11.14)(typescript@5.9.3)
       '@nuxt/schema': 4.4.2
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.4.2(magicast@0.5.2))
-      '@nuxt/vite-builder': 4.4.2(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.2.2)(eslint@9.39.2(jiti@2.6.1))(lightningcss@1.31.1)(magicast@0.5.2)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@parcel/watcher@2.5.6)(@types/node@25.2.2)(@vue/compiler-sfc@3.5.31)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.60.1))(rollup@4.60.1)(srvx@0.11.14)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))(vue-tsc@3.2.4(typescript@5.9.3))(yaml@2.8.3))(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(typescript@5.9.3)(vue-tsc@3.2.4(typescript@5.9.3))(vue@3.5.31(typescript@5.9.3))(yaml@2.8.3)
-      '@unhead/vue': 2.1.12(vue@3.5.31(typescript@5.9.3))
+      '@nuxt/vite-builder': 4.4.2(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.2.2)(eslint@9.39.2(jiti@2.6.1))(lightningcss@1.31.1)(magicast@0.5.2)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@parcel/watcher@2.5.6)(@types/node@25.2.2)(@vue/compiler-sfc@3.5.39)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.60.1))(rollup@4.60.1)(srvx@0.11.14)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))(vue-tsc@3.2.4(typescript@5.9.3))(yaml@2.8.3))(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(typescript@5.9.3)(vue-tsc@3.2.4(typescript@5.9.3))(vue@3.5.39(typescript@5.9.3))(yaml@2.8.3)
+      '@unhead/vue': 2.1.12(vue@3.5.39(typescript@5.9.3))
       '@vue/shared': 3.5.31
       c12: 3.3.4(magicast@0.5.2)
       chokidar: 5.0.0
@@ -11999,8 +12035,8 @@ snapshots:
       unplugin: 3.0.0
       unrouting: 0.1.7
       untyped: 2.0.0
-      vue: 3.5.31(typescript@5.9.3)
-      vue-router: 5.0.4(@vue/compiler-sfc@3.5.31)(vue@3.5.31(typescript@5.9.3))
+      vue: 3.5.39(typescript@5.9.3)
+      vue-router: 5.0.4(@vue/compiler-sfc@3.5.39)(vue@3.5.39(typescript@5.9.3))
     optionalDependencies:
       '@parcel/watcher': 2.5.6
       '@types/node': 25.2.2
@@ -12486,9 +12522,9 @@ snapshots:
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.5.6:
+  postcss@8.5.16:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.15
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -12728,19 +12764,19 @@ snapshots:
     dependencies:
       jsesc: 3.1.0
 
-  reka-ui@2.7.0(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3)):
+  reka-ui@2.7.0(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)):
     dependencies:
       '@floating-ui/dom': 1.7.4
-      '@floating-ui/vue': 1.1.9(vue@3.5.31(typescript@5.9.3))
+      '@floating-ui/vue': 1.1.9(vue@3.5.39(typescript@5.9.3))
       '@internationalized/date': 3.11.0
       '@internationalized/number': 3.6.5
-      '@tanstack/vue-virtual': 3.13.18(vue@3.5.31(typescript@5.9.3))
+      '@tanstack/vue-virtual': 3.13.18(vue@3.5.39(typescript@5.9.3))
       '@vueuse/core': 12.8.2(typescript@5.9.3)
       '@vueuse/shared': 12.8.2(typescript@5.9.3)
       aria-hidden: 1.2.6
       defu: 6.1.6
       ohash: 2.0.11
-      vue: 3.5.31(typescript@5.9.3)
+      vue: 3.5.39(typescript@5.9.3)
     transitivePeerDependencies:
       - '@vue/composition-api'
       - typescript
@@ -13232,7 +13268,7 @@ snapshots:
       unplugin: 3.0.0
       unplugin-utils: 0.3.1
 
-  unplugin-auto-import@21.0.0(@nuxt/kit@4.3.0(magicast@0.5.2))(@vueuse/core@14.2.1(vue@3.5.31(typescript@5.9.3))):
+  unplugin-auto-import@21.0.0(@nuxt/kit@4.3.0(magicast@0.5.2))(@vueuse/core@14.2.1(vue@3.5.39(typescript@5.9.3))):
     dependencies:
       local-pkg: 1.1.2
       magic-string: 0.30.21
@@ -13242,14 +13278,14 @@ snapshots:
       unplugin-utils: 0.3.1
     optionalDependencies:
       '@nuxt/kit': 4.3.0(magicast@0.5.2)
-      '@vueuse/core': 14.2.1(vue@3.5.31(typescript@5.9.3))
+      '@vueuse/core': 14.2.1(vue@3.5.39(typescript@5.9.3))
 
   unplugin-utils@0.3.1:
     dependencies:
       pathe: 2.0.3
       picomatch: 4.0.3
 
-  unplugin-vue-components@31.0.0(@nuxt/kit@4.3.0(magicast@0.5.2))(vue@3.5.31(typescript@5.9.3)):
+  unplugin-vue-components@31.0.0(@nuxt/kit@4.3.0(magicast@0.5.2))(vue@3.5.39(typescript@5.9.3)):
     dependencies:
       chokidar: 5.0.0
       local-pkg: 1.1.2
@@ -13260,7 +13296,7 @@ snapshots:
       tinyglobby: 0.2.15
       unplugin: 2.3.11
       unplugin-utils: 0.3.1
-      vue: 3.5.31(typescript@5.9.3)
+      vue: 3.5.39(typescript@5.9.3)
     optionalDependencies:
       '@nuxt/kit': 4.3.0(magicast@0.5.2)
 
@@ -13377,11 +13413,11 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vaul-vue@0.4.1(reka-ui@2.7.0(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3)))(vue@3.5.31(typescript@5.9.3)):
+  vaul-vue@0.4.1(reka-ui@2.7.0(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))(vue@3.5.39(typescript@5.9.3)):
     dependencies:
-      '@vueuse/core': 10.11.1(vue@3.5.31(typescript@5.9.3))
-      reka-ui: 2.7.0(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3))
-      vue: 3.5.31(typescript@5.9.3)
+      '@vueuse/core': 10.11.1(vue@3.5.39(typescript@5.9.3))
+      reka-ui: 2.7.0(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3))
+      vue: 3.5.39(typescript@5.9.3)
     transitivePeerDependencies:
       - '@vue/composition-api'
 
@@ -13449,7 +13485,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-vue-tracer@1.3.0(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))(vue@3.5.31(typescript@5.9.3)):
+  vite-plugin-vue-tracer@1.3.0(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))(vue@3.5.39(typescript@5.9.3)):
     dependencies:
       estree-walker: 3.0.3
       exsolve: 1.0.8
@@ -13457,7 +13493,7 @@ snapshots:
       pathe: 2.0.3
       source-map-js: 1.2.1
       vite: 7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3)
-      vue: 3.5.31(typescript@5.9.3)
+      vue: 3.5.39(typescript@5.9.3)
 
   vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3):
     dependencies:
@@ -13520,9 +13556,9 @@ snapshots:
 
   vue-component-type-helpers@3.2.2: {}
 
-  vue-demi@0.14.10(vue@3.5.31(typescript@5.9.3)):
+  vue-demi@0.14.10(vue@3.5.39(typescript@5.9.3)):
     dependencies:
-      vue: 3.5.31(typescript@5.9.3)
+      vue: 3.5.39(typescript@5.9.3)
 
   vue-devtools-stub@0.1.0: {}
 
@@ -13538,16 +13574,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vue-router@4.6.4(vue@3.5.31(typescript@5.9.3)):
+  vue-router@4.6.4(vue@3.5.39(typescript@5.9.3)):
     dependencies:
       '@vue/devtools-api': 6.6.4
-      vue: 3.5.31(typescript@5.9.3)
+      vue: 3.5.39(typescript@5.9.3)
     optional: true
 
-  vue-router@5.0.4(@vue/compiler-sfc@3.5.31)(vue@3.5.31(typescript@5.9.3)):
+  vue-router@5.0.4(@vue/compiler-sfc@3.5.39)(vue@3.5.39(typescript@5.9.3)):
     dependencies:
       '@babel/generator': 7.29.1
-      '@vue-macros/common': 3.1.2(vue@3.5.31(typescript@5.9.3))
+      '@vue-macros/common': 3.1.2(vue@3.5.39(typescript@5.9.3))
       '@vue/devtools-api': 8.1.1
       ast-walker-scope: 0.8.3
       chokidar: 5.0.0
@@ -13562,10 +13598,10 @@ snapshots:
       tinyglobby: 0.2.15
       unplugin: 3.0.0
       unplugin-utils: 0.3.1
-      vue: 3.5.31(typescript@5.9.3)
+      vue: 3.5.39(typescript@5.9.3)
       yaml: 2.8.3
     optionalDependencies:
-      '@vue/compiler-sfc': 3.5.31
+      '@vue/compiler-sfc': 3.5.39
 
   vue-tsc@3.2.4(typescript@5.9.3):
     dependencies:
@@ -13573,13 +13609,13 @@ snapshots:
       '@vue/language-core': 3.2.4
       typescript: 5.9.3
 
-  vue@3.5.31(typescript@5.9.3):
+  vue@3.5.39(typescript@5.9.3):
     dependencies:
-      '@vue/compiler-dom': 3.5.31
-      '@vue/compiler-sfc': 3.5.31
-      '@vue/runtime-dom': 3.5.31
-      '@vue/server-renderer': 3.5.31(vue@3.5.31(typescript@5.9.3))
-      '@vue/shared': 3.5.31
+      '@vue/compiler-dom': 3.5.39
+      '@vue/compiler-sfc': 3.5.39
+      '@vue/runtime-dom': 3.5.39
+      '@vue/server-renderer': 3.5.39(vue@3.5.39(typescript@5.9.3))
+      '@vue/shared': 3.5.39
     optionalDependencies:
       typescript: 5.9.3
 

--- a/app/server/api/aps/export-derivatives.post.ts
+++ b/app/server/api/aps/export-derivatives.post.ts
@@ -2,7 +2,7 @@ import archiver from 'archiver'
 import { PassThrough } from 'node:stream'
 import { parseExportBody, sanitizeFolderName, inferMimeType } from '../../utils/aps-download'
 import { mergePdfBuffers } from '../../utils/pdf-merge'
-import { validateRegion, sanitizeHeaderFilename } from '../../utils/validation'
+import { validateRegion, sanitizeHeaderFilename, resolveDownloadBaseName } from '../../utils/validation'
 
 interface DerivativeFile {
   name: string
@@ -21,6 +21,10 @@ export default eventHandler(async (event) => {
   const rawToken = await getApsAccessToken(event)
 
   const region = validateRegion(body.region as string | undefined)
+
+  // Base name for the downloaded file(s); provided by the client
+  // (model or project name), falls back to a generic name
+  const baseName = resolveDownloadBaseName(body.filename)
 
   // Download all derivatives from all file groups in parallel
   const allDownloads = await Promise.all(
@@ -58,7 +62,7 @@ export default eventHandler(async (event) => {
     const mergedFiles: DerivativeFile[] = []
     if (pdfs.length > 0) {
       const merged = await mergePdfBuffers(pdfs.map(f => f.data))
-      mergedFiles.push({ name: 'merged.pdf', data: merged })
+      mergedFiles.push({ name: `${baseName}.pdf`, data: merged })
     }
     mergedFiles.push(...others)
     outputGroups = [{ name: 'merged', files: mergedFiles }]
@@ -108,12 +112,12 @@ export default eventHandler(async (event) => {
       } else {
         const allBuffers = outputGroups.flatMap(g => g.files.map(f => f.data))
         const merged = await mergePdfBuffers(allBuffers)
-        singleFile = { name: 'merged.pdf', data: merged }
+        singleFile = { name: `${baseName}.pdf`, data: merged }
       }
 
       setResponseHeaders(event, {
         'Content-Type': 'application/pdf',
-        'Content-Disposition': 'attachment; filename="derivatives.pdf"'
+        'Content-Disposition': `attachment; filename="${baseName}.pdf"`
       })
       return singleFile.data
     }
@@ -134,7 +138,7 @@ export default eventHandler(async (event) => {
   // zip: true (or forced for mixed content)
   setResponseHeaders(event, {
     'Content-Type': 'application/zip',
-    'Content-Disposition': 'attachment; filename="derivatives.zip"'
+    'Content-Disposition': `attachment; filename="${baseName}.zip"`
   })
 
   const archive = archiver('zip', { zlib: { level: 5 } })

--- a/app/server/api/aps/item-urn.get.ts
+++ b/app/server/api/aps/item-urn.get.ts
@@ -9,6 +9,8 @@ interface ApsTipResponse {
       displayName?: string
       name?: string
       versionNumber?: number
+      lastModifiedTime?: string
+      createTime?: string
     }
   }
 }

--- a/app/server/api/aps/manifest.get.ts
+++ b/app/server/api/aps/manifest.get.ts
@@ -1,5 +1,5 @@
 import type { ApsManifest } from '~/types/derivatives'
-import { filterDerivatives, extractViewSets, checkRevitVersion } from '../../utils/derivatives'
+import { normalizeManifestResponse, emptyManifestResponse } from '../../utils/derivatives'
 import { validateUrn, validateRegion } from '../../utils/validation'
 
 export default eventHandler(async (event) => {
@@ -14,32 +14,23 @@ export default eventHandler(async (event) => {
 
   const token = await getApsAccessToken(event)
 
-  const manifest = await apsFetch<ApsManifest>(
-    token,
-    modelDerivativePath(`/modelderivative/v2/designdata/${urn}/manifest`, region),
-    region
-  )
-
-  const firstDerivative = manifest.derivatives[0]
-  if (!firstDerivative) {
-    return {
-      modelName: 'Unknown',
-      derivatives: [],
-      viewSets: [],
-      revitVersionSupported: false,
-      revitVersion: null
+  let manifest: ApsManifest
+  try {
+    manifest = await apsFetch<ApsManifest>(
+      token,
+      modelDerivativePath(`/modelderivative/v2/designdata/${urn}/manifest`, region),
+      region
+    )
+  } catch (err) {
+    // No manifest = model has no published derivatives; a valid empty state,
+    // not a server error
+    if ((err as { statusCode?: number }).statusCode === 404) {
+      console.info(`[manifest] 404 from APS — no manifest/published derivatives (urn=${urn.slice(0, 24)}..., region=${region || 'US'})`)
+      return emptyManifestResponse()
     }
+    // Unexpected APS/server error — propagate (auth handling relies on status)
+    throw err
   }
 
-  const derivatives = filterDerivatives(firstDerivative.children)
-  const viewSets = extractViewSets(derivatives)
-  const { supported: revitVersionSupported, version: revitVersion } = checkRevitVersion(firstDerivative)
-
-  return {
-    modelName: firstDerivative.name,
-    derivatives,
-    viewSets,
-    revitVersionSupported,
-    revitVersion
-  }
+  return normalizeManifestResponse(manifest)
 })

--- a/app/server/tests/aps/derivative-filtering.test.ts
+++ b/app/server/tests/aps/derivative-filtering.test.ts
@@ -21,6 +21,37 @@ import {
   mockDerivativeNoVersion
 } from '../fixtures/manifest'
 
+describe('filterDerivatives defensive input handling', () => {
+  it('returns empty array for undefined, null, or non-array children', () => {
+    expect(filterDerivatives(undefined)).toEqual([])
+    expect(filterDerivatives(null)).toEqual([])
+    expect(filterDerivatives('bogus' as never)).toEqual([])
+    expect(filterDerivatives({} as never)).toEqual([])
+  })
+
+  it('skips null or non-object entries in children', () => {
+    const children = [null, undefined, 42, 'str', mockPdfChild1] as never[]
+    const result = filterDerivatives(children)
+    expect(result).toHaveLength(1)
+    expect(result[0].guid).toBe('guid-a001-pdf')
+  })
+
+  it('tolerates a child whose children is not an array', () => {
+    const malformed = { ...mock3dChild, children: { bogus: true } as never }
+    const result = filterDerivatives([malformed])
+    // Falls back to the child's own urn; no throw
+    expect(result).toHaveLength(1)
+    expect(result[0].format).toBe('svf')
+  })
+
+  it('tolerates null entries inside a child children array', () => {
+    const malformed = { ...mockPdfChild1, children: [null, ...mockPdfChild1.children!] as never }
+    const result = filterDerivatives([malformed])
+    expect(result).toHaveLength(1)
+    expect(result[0].format).toBe('pdf')
+  })
+})
+
 describe('filterPdfDerivatives', () => {
   it('extracts pdf-page derivatives from children that have them', () => {
     const result = filterPdfDerivatives([mockPdfChild1, mockPdfChild2])

--- a/app/server/tests/aps/export-derivatives.test.ts
+++ b/app/server/tests/aps/export-derivatives.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { parseExportBody, sanitizeFolderName } from '../../utils/aps-download'
+import { resolveDownloadBaseName } from '../../utils/validation'
 
 describe('export-derivatives endpoint', () => {
   describe('legacy single-file request validation', () => {
@@ -157,6 +158,27 @@ describe('export-derivatives endpoint', () => {
 
     it('trims whitespace', () => {
       expect(sanitizeFolderName('  hello  ')).toBe('hello')
+    })
+  })
+
+  describe('resolveDownloadBaseName', () => {
+    it('uses the provided filename', () => {
+      expect(resolveDownloadBaseName('Tower A')).toBe('Tower A')
+    })
+
+    it('strips header-unsafe characters (CRLF, quotes, backslashes)', () => {
+      expect(resolveDownloadBaseName('bad"\r\nname\\')).toBe('badname')
+    })
+
+    it('replaces path separators and reserved characters', () => {
+      expect(resolveDownloadBaseName('a/b:c*d')).toBe('a_b_c_d')
+    })
+
+    it('defaults to "sPrint Download" when missing, empty, or non-string', () => {
+      expect(resolveDownloadBaseName(undefined)).toBe('sPrint Download')
+      expect(resolveDownloadBaseName('')).toBe('sPrint Download')
+      expect(resolveDownloadBaseName('   ')).toBe('sPrint Download')
+      expect(resolveDownloadBaseName(42)).toBe('sPrint Download')
     })
   })
 })

--- a/app/server/tests/aps/item-urn.test.ts
+++ b/app/server/tests/aps/item-urn.test.ts
@@ -20,4 +20,17 @@ describe('normalizeItemUrn', () => {
     expect(normalizeItemUrn({ ...base, attributes: { name: 'B' } }).name).toBe('B')
     expect(normalizeItemUrn({ ...base, attributes: {} }).name).toBe('Unknown')
   })
+
+  it('lastModifiedTime fallback: lastModifiedTime → createTime → null', () => {
+    const base = { id: 'urn:test' }
+    expect(normalizeItemUrn({
+      ...base,
+      attributes: { lastModifiedTime: '2026-07-01T12:00:00Z', createTime: '2026-06-01T12:00:00Z' }
+    }).lastModifiedTime).toBe('2026-07-01T12:00:00Z')
+    expect(normalizeItemUrn({
+      ...base,
+      attributes: { createTime: '2026-06-01T12:00:00Z' }
+    }).lastModifiedTime).toBe('2026-06-01T12:00:00Z')
+    expect(normalizeItemUrn({ ...base, attributes: {} }).lastModifiedTime).toBeNull()
+  })
 })

--- a/app/server/tests/aps/manifest.test.ts
+++ b/app/server/tests/aps/manifest.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { filterPdfDerivatives, extractPdfViewSets, checkRevitVersion } from '../../utils/derivatives'
+import { normalizeManifestResponse, emptyManifestResponse } from '../../utils/derivatives'
 import type { ApsManifest } from '~/types/derivatives'
 import {
   mockManifestWithPdfs,
@@ -7,36 +7,25 @@ import {
   mockManifestOldRevit
 } from '../fixtures/manifest'
 
-function normalizeManifest(manifest: ApsManifest) {
-  const firstDerivative = manifest.derivatives[0]
-  const derivatives = filterPdfDerivatives(firstDerivative.children)
-  const viewSets = extractPdfViewSets(derivatives)
-  const { supported: revitVersionSupported, version: revitVersion } = checkRevitVersion(firstDerivative)
-
-  return {
-    modelName: firstDerivative.name,
-    derivatives,
-    viewSets,
-    revitVersionSupported,
-    revitVersion
-  }
-}
+// filterDerivatives (not the deprecated PDF-only variant) surfaces non-PDF
+// formats too, so counts below include the 3D/thumbnail entries
+const normalizeManifest = normalizeManifestResponse
 
 describe('manifest endpoint response transformation', () => {
   it('normalizes manifest with PDFs into structured response', () => {
     const result = normalizeManifest(mockManifestWithPdfs)
 
     expect(result.modelName).toBe('TestModel.rvt')
-    expect(result.derivatives).toHaveLength(2)
+    expect(result.derivatives.filter(d => d.format === 'pdf')).toHaveLength(2)
     expect(result.viewSets).toHaveLength(2)
     expect(result.revitVersionSupported).toBe(true)
     expect(result.revitVersion).toBe(2024)
   })
 
-  it('returns empty derivatives for manifest with no 2d views', () => {
+  it('returns no PDFs or view sets for manifest with no 2d views', () => {
     const result = normalizeManifest(mockManifestNoPdfs)
 
-    expect(result.derivatives).toEqual([])
+    expect(result.derivatives.filter(d => d.format === 'pdf')).toEqual([])
     expect(result.viewSets).toEqual([])
     expect(result.modelName).toBe('TestModel.rvt')
   })
@@ -67,5 +56,52 @@ describe('manifest endpoint response transformation', () => {
     expect(first).toHaveProperty('name')
     expect(first).toHaveProperty('active')
     expect(first.active).toBe(true)
+  })
+})
+
+describe('manifest resilience (empty / malformed / 404)', () => {
+  const empty = emptyManifestResponse()
+
+  it('null manifest (APS 404 path) yields the empty response', () => {
+    expect(normalizeManifestResponse(null)).toEqual(empty)
+    expect(normalizeManifestResponse(undefined)).toEqual(empty)
+  })
+
+  it('manifest with empty derivatives array yields the empty response', () => {
+    expect(normalizeManifestResponse({ urn: 'u', derivatives: [] })).toEqual(empty)
+  })
+
+  it('manifest with non-array derivatives yields the empty response', () => {
+    const malformed = { urn: 'u', derivatives: 'oops' } as unknown as ApsManifest
+    expect(normalizeManifestResponse(malformed)).toEqual(empty)
+  })
+
+  it('derivative with no children yields no derivatives, does not throw', () => {
+    const manifest = {
+      urn: 'u',
+      derivatives: [{ name: 'Model.rvt', children: undefined }]
+    } as unknown as ApsManifest
+    const result = normalizeManifestResponse(manifest)
+    expect(result.modelName).toBe('Model.rvt')
+    expect(result.derivatives).toEqual([])
+    expect(result.viewSets).toEqual([])
+  })
+
+  it('derivative with non-array children does not throw', () => {
+    const manifest = {
+      urn: 'u',
+      derivatives: [{ name: 'Model.rvt', children: { bogus: true } }]
+    } as unknown as ApsManifest
+    expect(normalizeManifestResponse(manifest).derivatives).toEqual([])
+  })
+
+  it('empty response shape matches the normal response shape', () => {
+    expect(empty).toEqual({
+      modelName: 'Unknown',
+      derivatives: [],
+      viewSets: [],
+      revitVersionSupported: false,
+      revitVersion: null
+    })
   })
 })

--- a/app/server/utils/aps-item.ts
+++ b/app/server/utils/aps-item.ts
@@ -2,7 +2,7 @@ import { encodeUrn } from './urn'
 
 interface ApsTipData {
   id: string
-  attributes: { displayName?: string, name?: string, versionNumber?: number }
+  attributes: { displayName?: string, name?: string, versionNumber?: number, lastModifiedTime?: string, createTime?: string }
 }
 
 export function normalizeItemUrn(data: ApsTipData) {
@@ -10,6 +10,7 @@ export function normalizeItemUrn(data: ApsTipData) {
   return {
     urn: encodeUrn(versionUrn),
     versionUrn,
-    name: data.attributes.displayName || data.attributes.name || 'Unknown'
+    name: data.attributes.displayName || data.attributes.name || 'Unknown',
+    lastModifiedTime: data.attributes.lastModifiedTime ?? data.attributes.createTime ?? null
   }
 }

--- a/app/server/utils/derivatives.ts
+++ b/app/server/utils/derivatives.ts
@@ -1,4 +1,56 @@
-import type { ApsManifestChild, ApsManifestDerivative, Derivative, DerivativeFormat, ViewSet } from '~/types/derivatives'
+import type { ApsManifest, ApsManifestChild, ApsManifestDerivative, Derivative, DerivativeFormat, ViewSet } from '~/types/derivatives'
+
+export interface ManifestResponse {
+  modelName: string
+  derivatives: Derivative[]
+  viewSets: ViewSet[]
+  revitVersionSupported: boolean
+  revitVersion: number | null
+}
+
+export function emptyManifestResponse(): ManifestResponse {
+  return {
+    modelName: 'Unknown',
+    derivatives: [],
+    viewSets: [],
+    revitVersionSupported: false,
+    revitVersion: null
+  }
+}
+
+/**
+ * Turns a raw APS manifest into the API response. Defensive: a missing,
+ * empty, or malformed manifest yields an empty response (the UI renders
+ * its "no published print sets" state) instead of throwing.
+ */
+export function normalizeManifestResponse(manifest: ApsManifest | null | undefined): ManifestResponse {
+  if (!manifest) return emptyManifestResponse()
+  if (!Array.isArray(manifest.derivatives)) {
+    console.warn('[manifest] Malformed manifest: derivatives is not an array')
+    return emptyManifestResponse()
+  }
+
+  const firstDerivative = manifest.derivatives[0]
+  if (!firstDerivative || typeof firstDerivative !== 'object') {
+    // Valid condition: nothing published for this model yet
+    return emptyManifestResponse()
+  }
+  if (firstDerivative.children !== undefined && !Array.isArray(firstDerivative.children)) {
+    console.warn('[manifest] Malformed manifest: derivative children is not an array')
+  }
+
+  const derivatives = filterDerivatives(firstDerivative.children)
+  const viewSets = extractViewSets(derivatives)
+  const { supported: revitVersionSupported, version: revitVersion } = checkRevitVersion(firstDerivative)
+
+  return {
+    modelName: firstDerivative.name || 'Unknown',
+    derivatives,
+    viewSets,
+    revitVersionSupported,
+    revitVersion
+  }
+}
 
 function normalizeViewSets(viewSets: string | string[] | undefined): string[] {
   if (!viewSets) return []
@@ -36,12 +88,16 @@ export function resolveMimeType(format: DerivativeFormat): string {
   return map[format]
 }
 
-export function filterDerivatives(children: ApsManifestChild[], formats?: DerivativeFormat[]): Derivative[] {
+export function filterDerivatives(children: ApsManifestChild[] | null | undefined, formats?: DerivativeFormat[]): Derivative[] {
   const result: Derivative[] = []
+  if (!Array.isArray(children)) return result
 
   for (const child of children) {
+    if (!child || typeof child !== 'object') continue
+    const subChildren = Array.isArray(child.children) ? child.children.filter(c => c && typeof c === 'object') : []
+
     // Check for pdf-page sub-children (existing pattern)
-    const pdfChild = child.children?.find(c => c.role === 'pdf-page')
+    const pdfChild = subChildren.find(c => c.role === 'pdf-page')
     if (pdfChild) {
       const format: DerivativeFormat = 'pdf'
       if (formats && !formats.includes(format)) continue
@@ -74,8 +130,8 @@ export function filterDerivatives(children: ApsManifestChild[], formats?: Deriva
     }
 
     // Recurse into children for nested derivatives (non-pdf-page)
-    if (child.children) {
-      for (const sub of child.children) {
+    if (subChildren.length > 0) {
+      for (const sub of subChildren) {
         if (sub.role === 'pdf-page') continue // Already handled
         if (!sub.urn) continue
         const format = resolveFormat(sub)

--- a/app/server/utils/validation.ts
+++ b/app/server/utils/validation.ts
@@ -46,3 +46,19 @@ export function sanitizeHeaderFilename(name: string): string {
   const sanitized = name.replace(/[\r\n"\\]/g, '').trim()
   return sanitized || 'download'
 }
+
+const DEFAULT_DOWNLOAD_BASE_NAME = 'sPrint Download'
+
+/**
+ * Resolves the base name for exported downloads from the client-provided
+ * filename (model or project name). Strips header-unsafe and path
+ * characters; falls back to a generic name.
+ */
+export function resolveDownloadBaseName(requested: unknown): string {
+  if (typeof requested !== 'string' || !requested.trim()) return DEFAULT_DOWNLOAD_BASE_NAME
+  const sanitized = requested
+    .replace(/[\r\n"\\]/g, '')
+    .replace(/[<>:/|?*]/g, '_')
+    .trim()
+  return sanitized || DEFAULT_DOWNLOAD_BASE_NAME
+}

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1,0 +1,78 @@
+# sPrint User Guide
+
+sPrint is a web app that lets you batch-export vector PDFs (and other derivatives) from published Revit models in Autodesk Construction Cloud (ACC) or BIM 360 — in seconds, without leaving your browser.
+
+---
+
+## Getting Started
+
+1. Open sPrint in your browser and click **Sign in with Autodesk**.
+2. Authorize sPrint to access your ACC / BIM 360 account.
+3. You land on the dashboard, ready to browse your projects.
+
+---
+
+## Exporting PDFs
+
+### 1. Find Your Model
+
+The project tree on the left shows your ACC / BIM 360 hubs and projects. Click through:
+
+**Hub → Project → Folder → .RVT file**
+
+Use the search bar to filter Revit files by name.
+
+### 2. Select Sheets or View Sets
+
+Click a `.RVT` file to open its published sheets and derivatives. From here you can:
+
+- Search sheets by name or number
+- Filter by format (PDF, DWG, IFC, etc.)
+- Select individual sheets or entire view sets
+- Preview a sheet before selecting it
+
+The **Selected Files** panel on the right shows everything queued for export.
+
+### 3. Configure Export Options
+
+Before downloading, choose how to package your export:
+
+| Option | Description |
+|--------|-------------|
+| **Merge** | Combine sheets into a single PDF, one per model, or keep separate |
+| **Zip output** | Bundle all files into a single `.zip` download |
+| **Model folders** | Organize downloaded files into per-model subfolders |
+
+### 4. Export
+
+Click **Export** to download your selected files. Large exports are packaged automatically.
+
+---
+
+## Tips
+
+- **Multi-model exports:** Select sheets from multiple `.RVT` files before exporting — they all queue in the Selected Files panel.
+- **View sets:** Selecting a view set selects all sheets within it. Deselect individual sheets to exclude them.
+- **Preview:** Click any sheet thumbnail to open a full preview before adding it to your export queue.
+
+---
+
+## FAQ
+
+**What file formats can I export?**
+PDFs are the primary format. sPrint also supports DWG, IFC, and other published derivatives depending on what your model has been published with.
+
+**My project isn't showing up. What do I do?**
+Make sure you have at least Viewer access to the project in ACC / BIM 360. If your hub is not listed, use the **Add Hub** option in the project tree.
+
+**Sheets are missing or outdated.**
+sPrint shows derivatives from the most recently published version of your model. If sheets are missing, check that the model has been published in ACC / BIM 360 and that the publish job completed successfully.
+
+**The export is taking a long time.**
+Large exports with many sheets can take a minute to package. Keep the browser tab open until the download starts. If it stalls, try exporting in smaller batches.
+
+**Can I export from multiple projects at once?**
+Yes. Navigate between projects and add sheets to your queue. The Selected Files panel tracks everything across projects until you export.
+
+**I don't see the PDF option for my model.**
+PDFs are only available if your Revit model was published with 2D views. If only 3D is published, you will see IFC and other 3D derivative options instead.


### PR DESCRIPTION
## Summary

Stabilization sprint with goal to make sPrint feel like a simple PDF/print-set download tool for normal users while keeping full model-derivative access for technical users. No derivative capability is removed, non-PDF data just moves behind a disclosure.

Also fixes three bugs found during QA: unhandled manifest parsing errors, APS manifest 404s surfacing as server 500s, and a first-expand "Loading..." hang in the project tree.

## What changed

### For normal users (P0/P1)
- **PDF-first panel** — selecting a model shows Print Sets + PDF sheets only. "Show advanced model data (N)" reveals everything else (3D Views, Model Data, Thumbnails / Previews, Design Data), each still previewable/downloadable.
- **Print Sets always visible** — renamed from "View Sets"; empty models show *"No published print sets found for this model."*
- **Sensible download names** — `derivatives.zip` is gone. One model → `<ModelName>.pdf/zip`; several models from one project → `<ProjectName>.zip`; mixed → `sPrint Download.zip`.
- **Download language** — "Download N PDFs", "Preparing download...", "Download complete". Trash icon replaced with a neutral "Clear selection" eraser.
- **Last published** — `Last published: <date>` shown per selected model (from the APS tip version, previously discarded).
- **Search fixed** — the project filter matches hub/project names only, never nested files/folders; expanding a match shows the normal folder tree.
- **Nothing looks empty** — adding an external project, loading a manual hub, or picking a search result auto-expands the tree to the content.
- **Persistence** — external projects and manual hub IDs survive reloads (localStorage; rehydrated lazily, zero startup API calls). Removable via an ✕ on the node.
- **Favorites (P2)** — star any project; favorites render as a chip row above the tree; clicking a chip loads/expands down to the project, scrolls to it, and flashes the row.

### Bug fixes
| Bug | Root cause | Fix |
|---|---|---|
| `children is not iterable` 500s on `/api/aps/manifest` | `filterDerivatives` assumed every manifest child array exists | Defensive parsing; malformed structures log a warning and degrade to empty |
| APS manifest 404 → unhandled server error | 404 propagated as exception | Treated as "no published derivatives": HTTP 200 empty response, UI shows its empty state |
| First project expand hangs on "Loading..." until collapse/re-expand | Tree ref was converted to `shallowRef` (TS workaround); UTree branches render `item.children` in place, so lazily committed children were invisible to reactivity. Compounded by reka-ui toggle-direction semantics changing under controlled expansion | Deep `ref` restored (`as Ref<>` cast solves the TS depth error instead); lazy loading is toggle-direction-agnostic with an in-flight dedupe flag and a retryable error state |

## Deliberate decisions
- **PostHog event names unchanged** (`export_started/completed/failed`) despite the Download copy — dashboard continuity.
- **Auth untouched** — persistence is pure client metadata; httpOnly cookie flow and the global 401 handler are not modified.
- **Favorites are a chip row**, not a pinned synthetic hub — a synthetic hub can't receive lazily loaded children without duplicating tree-node identity.
- **Client-computed filename wins** over Content-Disposition — avoids non-ASCII header issues; the header remains correct for non-browser clients.

## Test plan
- 211 unit tests pass (≈30 new): download naming matrix, filename sanitization, project-only tree filter, manifest resilience (404 / empty / malformed / null children), lazy-load reactivity regression (pins the shallowRef failure mode), persistence dedupe/rehydration, favorites toggle.
- Lint clean; typecheck adds zero errors over the pre-existing baseline (46, all in legacy test files + UserMenu.vue, down from ~57).
- Manual QA with real APS credentials: CAN-hub regression (no forced logout), download filename matrix, first-expand loading, favorites jump across hubs, external project persistence across reloads, offline error/retry state.

## Risks
- Controlled `UTree` expansion is the largest behavioral change to the tree; regression surface is expand/collapse + filter interplay (manually QA'd).
- Favorite-row scroll targeting relies on reka-ui's `role="treeitem"` markup; a Nuxt UI major bump could no-op the scroll (graceful).
- `revitVersionSupported: false` in empty manifest responses is benign only because the client checks derivative count — noted for future client consumers.

## Follow-ups (not in this PR)
- Deep-expand to a search-result file (needs folder-ID chains from the SSE endpoint).
- Manual-hub remove affordance (external projects have one).
- `buildAccProjectUrl` maps region `'CA'` but hubs report `'CAN'` — ACC deep links from Canadian hubs fall back to the US host (cosmetic, pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

